### PR TITLE
Task/mov 403 api accepts binary data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .classpath
 .editorconfig
 .project
@@ -5,6 +6,7 @@
 .gradle
 bin
 build
+out
 file-uploads
 
 # Folders created by docker container

--- a/README.adoc
+++ b/README.adoc
@@ -38,8 +38,23 @@ The Collector API is accessable via `https://localhost:8080/api/v2`.
 To overwrite the default keystores used by the Cyface data collector just place them as `keystore.tls.jks` and
 `keystore.jwt.jceks` inside the folder `secrets` right next to the `docker-compose.yml`.
 
-To generate a keystore and truststore, see
-https://cyface.atlassian.net/wiki/spaces/IM/pages/590348308/Einrichtung+eines+Kunden-Servers+und+einer+Kunden-App[restricted Cyface Confluence].
+To generate a keystore and truststore using https://keystore-explorer.org/[Keystore Explorer]:
+
+* Create a *new KeyStore* (PKCS12)
+** Go to Tools/*Generate Key Pair*
+*** You can use the default setting on the first configuration screen
+*** Use the button next to the **name** field on the second screen to enter your hostname or IP address as CN
+*** You may use the CN value as alias on the next screen, too
+*** Define an encryption password for the private key
+** Right click on the newly generated Key Pair and select *Export/Certificate* (.cer)
+** Save the keystore as *keystore.tls.jks (keystore type is PKCS12)
+
+  The keystore file must be kept private and is copied to the data-collector/secret folder.
+
+* Go to *Tools/Import Trusted Certificate*, select the .cer file (overwrite: ok)
+** Use "save as" to export the certificate as "truststore" (truststore.jks) (type: PKCS12)
+
+  The truststore file is copied to the android-backend/res/raw folder.
 
 ==== docker-clean.sh
 
@@ -89,7 +104,6 @@ A running Cyface data collector publishes metrics to a running https://prometheu
 * Setup Cluster
 	* Vertx
 	* MongoDb
-* Move Certificate creation instructions to readme
 
 == Licensing
 Copyright 2018 Cyface GmbH

--- a/README.adoc
+++ b/README.adoc
@@ -7,7 +7,60 @@ image:https://img.shields.io/badge/grafana-5.3.0.svg[link="https://grafana.com/"
 
 This application was generated using http://start.vertx.io
 
+== Help
+
+* https://vertx.io/docs/[Vert.x Documentation]
+* https://stackoverflow.com/questions/tagged/vert.x?sort=newest&pageSize=15[Vert.x Stack Overflow]
+* https://groups.google.com/forum/?fromgroups#!forum/vertx[Vert.x User Group]
+* https://gitter.im/eclipse-vertx/vertx-users[Vert.x Gitter]
+
 == Building
+
+Simply run `build.sh` inside the root of this project. This builds the jar file which is then packed into the Docker
+container which is build afterwards. This script also makes sure all required subdirectories are created.
+
+== Execution
+This section describes how to execute the Cyface data collector.
+
+=== Running from Docker
+Simply run `start.sh` inside the root of this project. This calls docker to bring up two Mongo database containers and a container running the Cyface data collector API.
+In addition it starts https://prometheus.io/[Prometheus] and https://grafana.com/[Grafana] as monitoring tools for the running server.
+
+Prometheus stores all the metrics data, while Grafana provides a dashboard for visualization.
+Per default the Grafana dashboard is available via port 3000. The Collector API is by default available via port 8080.
+
+This means if you boot up everything using the default settings you can access Grafana via `http://localhost:3000`.
+The default username is *cyface-admin* and the default password *cyface-admin@grafana*.
+The Collector API is accessable via `https://localhost:8080/api/v2`.
+
+==== Certificates
+
+To overwrite the default keystores used by the Cyface data collector just place them as `keystore.tls.jks` and
+`keystore.jwt.jceks` inside the folder `secrets` right next to the `docker-compose.yml`.
+
+To generate a keystore and truststore, see
+https://cyface.atlassian.net/wiki/spaces/IM/pages/590348308/Einrichtung+eines+Kunden-Servers+und+einer+Kunden-App[restricted Cyface Confluence].
+
+==== docker-clean.sh
+
+The script `docker-clean.sh` stops all the Docker containers and deletes all the data.
+
+**ATTENTION:** You will loose **ALL** data if you run this script and will have to start with a fresh installation.
+Only use this script if you are really sure and if you have a backup of all data you wish to keep.
+
+=== Command Line Arguments
+The Cyface data collector supports a few parameters to fine tune the runtime. All of these parameters also provide reasonable defaults for quick setup. In production you should change those values to fit your environment. The parameters are provided using the typical Vertx `-conf` parameter with a value in JSON notation. The following parameters are supported:
+
+* **keystore.jwt:** The path of the keystore used to sign JWT keys. This defaults to the keystore available under `src/main/resources/keystore.jceks`, which you should never use in production.
+* **keystore.jwt.password:** The password to access the JWT keystore file.
+* **keystore.tls:** The path of the keystore used to encrypt HTTPS communication. This defaults to the keystore for localhost available under `src/main/resources/localhost.jks`. The default one will only work for a server reached using `localhost`. In production you will require your own file.
+* **keystore.tls.password:** The password to access the keystore used for HTTPS communication.
+* **http.port:** The port the API  is available at. This defaults to `8080`.
+* **mongo.userdb:** Settings for a Mongo database storing credential information about all the users capable of logging into the system. This defaults to a Mongo database available at `mongodb://127.0.0.1:27017`. The value of this should be a JSON object configured as described https://vertx.io/docs/vertx-mongo-client/java/#_configuring_the_client[here]. In addition, if you use two different Mongo databases for credentials and data you should provide different values for the JSON key `data_source_name`.
+* **mongo.datadb:** Settings for a Mongo database storing all data uploaded via the Cyface data collector. This defaults to a Mongo database available at `mongodb://127.0.0.1:27017`. The value of this should be a JSON object configured as described https://vertx.io/docs/vertx-mongo-client/java/#_configuring_the_client[here]. In addition, if you use two different Mongo databases for credentials and data you should provide different values for the JSON key `data_source_name`.
+* **metrics.enabled:** Set to either `true` or `false`. If `true` the collector API publishes metrics using micrometer. These metrics are accessible by a https://prometheus.io/[Prometheus] server (Which you either need to setup yourself or use the Docker setup explained further down) at port `8081`.
+
+=== Running from Command Line
 
 To launch your tests:
 ```
@@ -24,44 +77,8 @@ To run your application:
 ./gradlew clean run
 ```
 
-== Help
-
-* https://vertx.io/docs/[Vert.x Documentation]
-* https://stackoverflow.com/questions/tagged/vert.x?sort=newest&pageSize=15[Vert.x Stack Overflow]
-* https://groups.google.com/forum/?fromgroups#!forum/vertx[Vert.x User Group]
-* https://gitter.im/eclipse-vertx/vertx-users[Vert.x Gitter]
-
-== Execution
-This section describes how to execute the Cyface data collector.
-
-=== Command Line Arguments
-The Cyface data collector supports a few parameters to fine tune the runtime. All of these parameters also provide reasonable defaults for quick setup. In production you should change those values to fit your environment. The parameters are provided using the typical Vertx `-conf` parameter with a value in JSON notation. The following parameters are supported:
-
-* **keystore.jwt:** The path of the keystore used to sign JWT keys. This defaults to the keystore available under `src/main/resources/keystore.jceks`, which you should never use in production.
-* **keystore.jwt.password:** The password to access the JWT keystore file.
-* **keystore.tls:** The path of the keystore used to encrypt HTTPS communication. This defaults to the keystore for localhost available under `src/main/resources/localhost.jks`. The default one will only work for a server reached using `localhost`. In production you will require your own file.
-* **keystore.tls.password:** The password to access the keystore used for HTTPS communication.
-* **http.port:** The port the API  is available at. This defaults to `8080`.
-* **mongo.userdb:** Settings for a Mongo database storing credential information about all the users capable of logging into the system. This defaults to a Mongo database available at `mongodb://127.0.0.1:27017`. The value of this should be a JSON object configured as described https://vertx.io/docs/vertx-mongo-client/java/#_configuring_the_client[here]. In addition, if you use two different Mongo databases for credentials and data you should provide different values for the JSON key `data_source_name`.
-* **mongo.datadb:** Settings for a Mongo database storing all data uploaded via the Cyface data collector. This defaults to a Mongo database available at `mongodb://127.0.0.1:27017`. The value of this should be a JSON object configured as described https://vertx.io/docs/vertx-mongo-client/java/#_configuring_the_client[here]. In addition, if you use two different Mongo databases for credentials and data you should provide different values for the JSON key `data_source_name`.
-* **metrics.enabled:** Set to either `true` or `false`. If `true` the collector API publishes metrics using micrometer. These metrics are accessible by a https://prometheus.io/[Prometheus] server (Which you either need to setup yourself or use the Docker setup explained further down) at port `8081`.
-
 === Running from IDE
 To run directly from within your IDE you need to use the `de.cyface.collector.Application` class, which is a subclass of the https://vertx.io/docs/vertx-core/java/#_the_vert_x_launcher[Vert.x launcher]. Just specify it as the main class in your launch configuration with the program argument `run de.cyface.collector.MainVerticle`.
-
-=== Running from Docker
-Simply run `start.sh` inside the root of this project. This calls docker to bring up two Mongo database containers and a container running the Cyface data collector API. 
-In addition it starts https://prometheus.io/[Prometheus] and https://grafana.com/[Grafana] as monitoring tools for the running server. 
-Prometheus stores all the metrics data, while Grafana provides a dashboard for visualization. 
-Per default the Grafana dashboard is available via port 3000. 
-This means if you boot up everything using the default settings you can access Grafana via `http://localhost:3000`. 
-The default username is *cyface-admin* and the default password *cyface-admin@grafana*.
-
-There is also a script called `docker-clean.sh`. This stops all the Docker containers and deletes all the data. 
-**ATTENTION:** You will loose **ALL** data if you run this script and will have to start with a fresh installation.
-Only use this script if you are really sure and if you have a backup of all data you wish to keep.
-
-To overwrite the default keystores used by the Cyface data collector just place them as `keystore.tls.jks` and `keystore.jwt.jceks` inside the folder `secrets` right next to the `docker-compose.yml`
 
 == Runtime Administration
 A running Cyface data collector publishes metrics to a running https://prometheus.io/docs/prometheus/latest/getting_started/[Prometheus] instance. If you have used the docker setup, this should happen automatically. Per default Prometheus is exposed on **http://localhost:9090/graph**.
@@ -72,6 +89,7 @@ A running Cyface data collector publishes metrics to a running https://prometheu
 * Setup Cluster
 	* Vertx
 	* MongoDb
+* Move Certificate creation instructions to readme
 
 == Licensing
 Copyright 2018 Cyface GmbH

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,29 @@
+#!/bin/bash -e
+# Copyright 2018 Cyface GmbH
+# version 1.0.0
+#
+# This file is part of the Cyface Data Collector.
+#
+#  The Cyface Data Collector is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  
+#  The Cyface Data Collector is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with the Cyface Data Collector.  If not, see <http://www.gnu.org/licenses/>.
+
+export CURRENT_UID=$(id -u):$(id -g)
+
+# Create volume directories
+mkdir -p data user-data secrets prometheus/data grafana/data grafana/logs
+
+# Build jar
+./gradlew clean assemble
+
+# Build docker container
+docker-compose build

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -e
 # Copyright 2018 Cyface GmbH
-# version 1.0.0
 #
 # This file is part of the Cyface Data Collector.
 #
@@ -16,6 +15,8 @@
 #
 #  You should have received a copy of the GNU General Public License
 #  along with the Cyface Data Collector.  If not, see <http://www.gnu.org/licenses/>.
+#
+# version 1.0.0
 
 export CURRENT_UID=$(id -u):$(id -g)
 

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
 #  (at your option) any later version.
-#  
+#
 #  The Cyface Data Collector is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -27,4 +27,4 @@ mkdir -p data user-data secrets prometheus/data grafana/data grafana/logs
 ./gradlew clean assemble
 
 # Build docker container
-docker-compose build
+docker-compose -p 'collector' build

--- a/docker-clean.sh
+++ b/docker-clean.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Copyright 2018 Cyface GmbH
+# version 1.0.0
 # 
 # This file is part of the Cyface Data Collector.
 #
@@ -18,22 +19,22 @@
 
 export CURRENT_UID=$(id -u):$(id -g)
 
-echo "Stopping running containers"
+printf "\nStopping running containers\n"
 docker-compose stop
 
-echo "Deleting containers"
-docker rm collector_api_1
-docker rm collector_prometheus_1
-docker rm collector_mongo-user_1
-docker rm collector_mongo-data_1
-docker rm collector_grafana_1
+printf "\nDeleting containers\n"
+docker rm data-collector_api_1
+docker rm data-collector_prometheus_1
+docker rm data-collector_mongo-user_1
+docker rm data-collector_mongo-data_1
+docker rm data-collector_grafana_1
 
-echo "Deleting custom images"
-docker rmi collector_api
-docker rmi collector_prometheus
-docker rmi collector_grafana
+printf "\nDeleting custom images\n"
+docker rmi data-collector_api
+docker rmi data-collector_prometheus
+docker rmi data-collector_grafana
 
-echo "Removing data from volumes"
+printf "\nRemoving data from volumes\n"
 rm -r ./grafana/data/*
 rm -r ./prometheus/data/*
 rm -r ./data/*

--- a/docker-clean.sh
+++ b/docker-clean.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 # Copyright 2018 Cyface GmbH
 # version 1.0.0
-# 
+#
 # This file is part of the Cyface Data Collector.
 #
 #  The Cyface Data Collector is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
 #  (at your option) any later version.
-#  
+#
 #  The Cyface Data Collector is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -20,19 +20,19 @@
 export CURRENT_UID=$(id -u):$(id -g)
 
 printf "\nStopping running containers\n"
-docker-compose stop
+docker stop collector_api collector_prometheus collector_mongo-user collector_mongo-data collector_grafana
 
 printf "\nDeleting containers\n"
-docker rm data-collector_api_1
-docker rm data-collector_prometheus_1
-docker rm data-collector_mongo-user_1
-docker rm data-collector_mongo-data_1
-docker rm data-collector_grafana_1
+docker rm collector_api
+docker rm collector_prometheus
+docker rm collector_mongo-user
+docker rm collector_mongo-data
+docker rm collector_grafana
 
 printf "\nDeleting custom images\n"
-docker rmi data-collector_api
-docker rmi data-collector_prometheus
-docker rmi data-collector_grafana
+docker rmi collector_api
+docker rmi collector_prometheus
+docker rmi collector_grafana
 
 printf "\nRemoving data from volumes\n"
 rm -r ./grafana/data/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with the Cyface Data Collector. If not, see <http://www.gnu.org/licenses/>.
+#
+# version 1.0.0
 
 version: "3"
 services:
@@ -38,7 +40,7 @@ services:
     api:
       build: .
       ports:
-        - "8080:8080"
+        - "127.0.0.1:8080:8080" # 127.0.0.1 avoids the manipulation of the host's ip-tables
       networks:
         - cyface
       volumes:
@@ -61,7 +63,7 @@ services:
     grafana:
       build: grafana
       ports:
-        - 3000:3000
+        - "127.0.0.1:3000:3000" # 127.0.0.1 avoids the manipulation of the host's ip-tables
       networks:
         - cyface
       volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ version: "3"
 services:
     # Mongo Database Container
     mongo-data:
+      container_name: collector_mongo-data
       image: mongo:4.0.3
       networks:
         - cyface
@@ -29,6 +30,7 @@ services:
       user: ${CURRENT_UID}
         
     mongo-user:
+      container_name: collector_mongo-user
       image: mongo:4.0.3
       networks:
         - cyface
@@ -38,6 +40,7 @@ services:
 
     # The Cyface Collector API Container
     api:
+      container_name: collector_api
       build: .
       ports:
         - "127.0.0.1:8080:8080" # 127.0.0.1 avoids the manipulation of the host's ip-tables
@@ -52,6 +55,7 @@ services:
         
     # Prometheus Metrics tool
     prometheus:
+      container_name: collector_prometheus
       build: prometheus
       networks:
         - cyface
@@ -61,6 +65,7 @@ services:
         
     # Grafana Dashboard on Prometheus Data
     grafana:
+      container_name: collector_grafana
       build: grafana
       ports:
         - "127.0.0.1:3000:3000" # 127.0.0.1 avoids the manipulation of the host's ip-tables

--- a/src/main/java/de/cyface/collector/MainVerticle.java
+++ b/src/main/java/de/cyface/collector/MainVerticle.java
@@ -131,7 +131,7 @@ public final class MainVerticle extends AbstractVerticle {
                     if (r.succeeded()) {
                         LOGGER.info("Authentication successful!");
                         String generatedToken = jwtAuthProvider.generateToken(body,
-                                new JWTOptions().setExpiresInSeconds(60*60)); // FIXME: for testing 1h is easier
+                                new JWTOptions().setExpiresInSeconds(60));
                         LOGGER.info("New JWT Token: " + generatedToken);
                         // Returning the token as response body because the RequestTest fails to read the header
                         // Returning the token as response header because Android fails to read the response body

--- a/src/main/java/de/cyface/collector/MainVerticle.java
+++ b/src/main/java/de/cyface/collector/MainVerticle.java
@@ -1,20 +1,16 @@
 /*
  * Copyright 2018 Cyface GmbH
- * 
  * This file is part of the Cyface Data Collector.
- *
- *  The Cyface Data Collector is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *  
- *  The Cyface Data Collector is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with the Cyface Data Collector.  If not, see <http://www.gnu.org/licenses/>.
+ * The Cyface Data Collector is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * The Cyface Data Collector is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with the Cyface Data Collector. If not, see <http://www.gnu.org/licenses/>.
  */
 package de.cyface.collector;
 
@@ -49,10 +45,11 @@ import io.vertx.ext.web.handler.JWTAuthHandler;
 /**
  * This Verticle is the Cyface collectors main entry point. It orchestrates all
  * other Verticles and configures the endpoints used to provide the REST-API.
- * 
+ *
  * @author Klemens Muthmann
- * @since 2.0.0
+ * @author Armin Schnabel
  * @version 1.0.0
+ * @since 2.0.0
  */
 public final class MainVerticle extends AbstractVerticle {
 
@@ -96,6 +93,8 @@ public final class MainVerticle extends AbstractVerticle {
      * @return The Vertx router used by this project.
      */
     private Router setupRoutes() {
+
+        // Set up authentication check
         final String keystorePath = this.getClass().getResource("/keystore.jceks").getFile();
         String jwtKeystoreLocation = Parameter.JWT_KEYSTORE.stringValue(vertx, keystorePath);
         final JWTAuthOptions config = new JWTAuthOptions()
@@ -105,8 +104,8 @@ public final class MainVerticle extends AbstractVerticle {
         final JWTAuth jwtAuthProvider = JWTAuth.create(vertx, config);
         final AuthHandler jwtAuthHandler = JWTAuthHandler.create(jwtAuthProvider, "/api/v2/login");
 
+        // Create test users
         final JsonObject mongoClientConfig = Parameter.MONGO_USER_DB.jsonValue(vertx, config());
-
         final MongoClient client = SerializationVerticle.createSharedMongoClient(vertx, mongoClientConfig);
         final JsonObject authProperties = new JsonObject();
         final MongoAuth authProvider = MongoAuth.create(client, authProperties);
@@ -119,9 +118,11 @@ public final class MainVerticle extends AbstractVerticle {
                     ir -> LOGGER.info("Identifier of new user id: " + ir));
         });
 
+        // Routing
         final Router mainRouter = Router.router(vertx);
         final Router v2ApiRouter = Router.router(vertx);
 
+        // Set up authentication route
         v2ApiRouter.route("/login").handler(BodyHandler.create()).handler(ctx -> {
             try {
                 JsonObject body = ctx.getBodyAsJson();
@@ -130,9 +131,12 @@ public final class MainVerticle extends AbstractVerticle {
                     if (r.succeeded()) {
                         LOGGER.info("Authentication successful!");
                         String generatedToken = jwtAuthProvider.generateToken(body,
-                                new JWTOptions().setExpiresInSeconds(60));
+                                new JWTOptions().setExpiresInSeconds(60*60)); // FIXME: for testing 1h is easier
                         LOGGER.info("New JWT Token: " + generatedToken);
-                        ctx.response().putHeader("Content-Type", "text/plain").setStatusCode(200).end(generatedToken);
+                        // Returning the token as response body because the RequestTest fails to read the header
+                        // Returning the token as response header because Android fails to read the response body
+                        ctx.response().putHeader("Authorization", generatedToken).setStatusCode(200)
+                                .end(generatedToken);
                     } else {
                         ctx.response().setStatusCode(401).end();
                     }
@@ -142,12 +146,17 @@ public final class MainVerticle extends AbstractVerticle {
                 ctx.response().setStatusCode(404).end();
             }
         });
+
+        // Set up default routes
         mainRouter.route().handler(jwtAuthHandler);
         mainRouter.route().last().handler(new DefaultHandler());
         mainRouter.mountSubRouter("/api/v2", v2ApiRouter);
 
+        // Set up Data Collector route
         v2ApiRouter.post("/measurements").handler(BodyHandler.create().setDeleteUploadedFilesOnEnd(false))
                 .handler(new MeasurementHandler());
+
+        // Handle unsupported routes
         v2ApiRouter.route().last().handler(new DefaultHandler());
 
         return mainRouter;
@@ -156,7 +165,7 @@ public final class MainVerticle extends AbstractVerticle {
     /**
      * Starts the HTTP server provided by this application. This server runs the
      * Cyface collector REST-API.
-     * 
+     *
      * @param router The router for all the endpoints the HTTP server should
      *            serve.
      * @param startFuture Informs the caller about the successful or failed start of
@@ -177,7 +186,7 @@ public final class MainVerticle extends AbstractVerticle {
     /**
      * Finishes the <code>MainVerticle</code> startup process and informs all
      * interested parties about whether it has been successful or not.
-     * 
+     *
      * @param serverStartup The result of the server startup as provided by <code>Vertx</code>.
      * @param future A future to call to inform all waiting parties about success or failure of the startup process.
      */

--- a/src/main/java/de/cyface/collector/handler/DefaultHandler.java
+++ b/src/main/java/de/cyface/collector/handler/DefaultHandler.java
@@ -42,6 +42,8 @@ public final class DefaultHandler implements Handler<RoutingContext> {
 
     @Override
     public void handle(RoutingContext context) {
+        LOGGER.info("Plain API called.");
+
         // This handler will be called for every request
         HttpServerResponse response = context.response();
         response.putHeader("content-type", "text/plain");

--- a/src/test/java/de/cyface/collector/RequestTest.java
+++ b/src/test/java/de/cyface/collector/RequestTest.java
@@ -217,14 +217,14 @@ public final class RequestTest {
 
                 final HttpRequest<Buffer> builder = client.post(port, "localhost", "/api/v2/measurements").ssl(true);
                 builder.putHeader("Authorization", "Bearer " + authToken);
-                builder.sendMultipartForm(form, ar -> {
-                    if (ar.succeeded()) {
-                        context.assertEquals(ar.result().statusCode(), 201);
-                        context.assertTrue(ar.succeeded());
-                        context.assertNull(ar.cause());
+                builder.sendMultipartForm(form, asyncResult -> {
+                    if (asyncResult.succeeded()) {
+                        context.assertEquals(asyncResult.result().statusCode(), 201);
+                        context.assertTrue(asyncResult.succeeded());
+                        context.assertNull(asyncResult.cause());
                         async.complete();
                     } else {
-                        context.fail(ar.cause());
+                        context.fail(asyncResult.cause());
                     }
                 });
             } else {

--- a/start.sh
+++ b/start.sh
@@ -1,14 +1,14 @@
 #!/bin/bash -e
 # Copyright 2018 Cyface GmbH
 # version 1.0.0
-# 
+#
 # This file is part of the Cyface Data Collector.
 #
 #  The Cyface Data Collector is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
 #  (at your option) any later version.
-#  
+#
 #  The Cyface Data Collector is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -18,9 +18,6 @@
 #  along with the Cyface Data Collector.  If not, see <http://www.gnu.org/licenses/>.
 
 export CURRENT_UID=$(id -u):$(id -g)
-	
-# Create volumne directories
-mkdir -p data user-data secrets prometheus/data grafana/data grafana/logs
-	
+
 # Start app
 docker-compose up -d

--- a/start.sh
+++ b/start.sh
@@ -21,4 +21,4 @@
 export CURRENT_UID=$(id -u):$(id -g)
 
 # Start app
-docker-compose up -d
+docker-compose -p 'collector' up -d

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,6 @@
-#!/bin/bash
+#!/bin/bash -e
 # Copyright 2018 Cyface GmbH
+# version 1.0.0
 # 
 # This file is part of the Cyface Data Collector.
 #
@@ -17,4 +18,9 @@
 #  along with the Cyface Data Collector.  If not, see <http://www.gnu.org/licenses/>.
 
 export CURRENT_UID=$(id -u):$(id -g)
+	
+# Create volumne directories
+mkdir -p data user-data secrets prometheus/data grafana/data grafana/logs
+	
+# Start app
 docker-compose up -d

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -e
 # Copyright 2018 Cyface GmbH
-# version 1.0.0
 #
 # This file is part of the Cyface Data Collector.
 #
@@ -16,6 +15,8 @@
 #
 #  You should have received a copy of the GNU General Public License
 #  along with the Cyface Data Collector.  If not, see <http://www.gnu.org/licenses/>.
+#
+# version 1.0.0
 
 export CURRENT_UID=$(id -u):$(id -g)
 


### PR DESCRIPTION
This PR clearifies the setup process from my standpoint as a newcomer to this project (readme, scripts).

It also adds the authToken to the login response header for the Android client (can't read the response body due to a bug).

It also secures the default setting so that the ip-tables are not manipulated by docker on default. We should add other security options to the start script as parameters close to the release.

It also fixes small bugs I found while setting up the API.