### PR TITLE
Change MultiPartHeader format received from clients CY-4680

### DIFF
--- a/src/main/java/de/cyface/collector/handler/FormAttributes.java
+++ b/src/main/java/de/cyface/collector/handler/FormAttributes.java
@@ -1,13 +1,13 @@
 /*
  * Copyright 2018 Cyface GmbH
- * 
+ *
  * This file is part of the Cyface Data Collector.
  *
  * The Cyface Data Collector is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * The Cyface Data Collector is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
@@ -22,7 +22,8 @@ package de.cyface.collector.handler;
  * Attributes supported by the APIs multipart form upload POST endpoint.
  * 
  * @author Klemens Muthmann
- * @version 1.1.0
+ * @author Armin Schnabel
+ * @version 2.0.0
  * @since 2.0.0
  */
 public enum FormAttributes {
@@ -54,6 +55,32 @@ public enum FormAttributes {
      * The count of geo locations in the transmitted measurement.
      */
     LOCATION_COUNT("locationCount"),
+    /**
+     * The latitude of the geo location at the beginning of the track represented by the transmitted measurement.
+     */
+    START_LOCATION_LAT("startLocLat"),
+    /**
+     * The longitude of the geo location at the beginning of the track represented by the transmitted measurement.
+     */
+    START_LOCATION_LON("startLocLon"),
+    /**
+     * The timestamp is milliseconds of the geo location at the beginning of the track represented by the transmitted
+     * measurement.
+     */
+    START_LOCATION_TS("startLocTS"),
+    /**
+     * The latitude of the geo location at the end of the track represented by the transmitted measurement.
+     */
+    END_LOCATION_LAT("endLocLat"),
+    /**
+     * The longitude of the geo location at the end of the track represented by the transmitted measurement.
+     */
+    END_LOCATION_LON("endLocLon"),
+    /**
+     * The timestamp is milliseconds of the geo end at the beginning of the track represented by the transmitted
+     * measurement.
+     */
+    END_LOCATION_TS("endLocTS"),
     /**
      * The geo location at the beginning of the track represented by the transmitted measurement.
      */

--- a/src/test/java/de/cyface/collector/FileUploadTest.java
+++ b/src/test/java/de/cyface/collector/FileUploadTest.java
@@ -55,7 +55,8 @@ import io.vertx.ext.web.multipart.MultipartForm;
  * Tests that uploading measurements to the Cyface API works as expected.
  * 
  * @author Klemens Muthmann
- * @version 3.0.0
+ * @author Armin Schnabel
+ * @version 3.0.1
  * @since 2.0.0
  */
 @RunWith(VertxUnitRunner.class)
@@ -86,7 +87,7 @@ public final class FileUploadTest {
      */
     private WebClient client;
     /**
-     * A globally unqiue identifier of the simulated upload device. The actual value does not really matter.
+     * A globally unique identifier of the simulated upload device. The actual value does not really matter.
      */
     private String deviceIdentifier = UUID.randomUUID().toString();
     /**
@@ -146,8 +147,12 @@ public final class FileUploadTest {
         form.attribute(FormAttributes.APPLICATION_VERSION.getValue(), "4.0.0-alpha1");
         form.attribute(FormAttributes.LENGTH.getValue(), "200.0");
         form.attribute(FormAttributes.LOCATION_COUNT.getValue(), "10");
-        form.attribute(FormAttributes.START_LOCATION.getValue(), "lat: 10.0 lon: 10.0, timestamp: 10000");
-        form.attribute(FormAttributes.END_LOCATION.getValue(), "lat: 12.0 lon: 12.0, timestamp: 12000");
+        form.attribute(FormAttributes.START_LOCATION_LAT.getValue(), "10.0");
+        form.attribute(FormAttributes.START_LOCATION_LON.getValue(), "10.0");
+        form.attribute(FormAttributes.START_LOCATION_TS.getValue(), "10000");
+        form.attribute(FormAttributes.END_LOCATION_LAT.getValue(), "12.0");
+        form.attribute(FormAttributes.END_LOCATION_LON.getValue(), "12.0");
+        form.attribute(FormAttributes.END_LOCATION_TS.getValue(), "12000");
     }
 
     /**
@@ -214,12 +219,12 @@ public final class FileUploadTest {
     }
 
     /**
-     * Tests that an upload with unparseable meta data returns a 422 error.
+     * Tests that an upload with unparsable meta data returns a 422 error.
      * 
      * @param context The test context for running <code>Vertx</code> under test.
      */
     @Test
-    public void testUploadWithUnparseableMetaData_Returns422(final TestContext context) {
+    public void testUploadWithUnParsableMetaData_Returns422(final TestContext context) {
         final Async async = context.async();
 
         // Set invalid value for a form attribute
@@ -231,8 +236,12 @@ public final class FileUploadTest {
         form.attribute(FormAttributes.APPLICATION_VERSION.getValue(), "4.0.0-alpha1");
         form.attribute(FormAttributes.LENGTH.getValue(), "Sir! You are being hacked!");
         form.attribute(FormAttributes.LOCATION_COUNT.getValue(), "10");
-        form.attribute(FormAttributes.START_LOCATION.getValue(), "lat: 10.0 lon: 10.0, timestamp: 10000");
-        form.attribute(FormAttributes.END_LOCATION.getValue(), "lat: 12.0 lon: 12.0, timestamp: 12000");
+        form.attribute(FormAttributes.START_LOCATION_LAT.getValue(), "10.0");
+        form.attribute(FormAttributes.START_LOCATION_LON.getValue(), "10.0");
+        form.attribute(FormAttributes.START_LOCATION_TS.getValue(), "10000");
+        form.attribute(FormAttributes.END_LOCATION_LAT.getValue(), "12.0");
+        form.attribute(FormAttributes.END_LOCATION_LON.getValue(), "12.0");
+        form.attribute(FormAttributes.END_LOCATION_TS.getValue(), "12000");
 
         // Execute
         upload(context, "/test.bin", ar -> {


### PR DESCRIPTION
Aufgrund der start/endLocation MultipartHeader Format  Änderung auf den Clients muss ich den Collector nun kompatibel machen, um einen offenen Client-Server Bug zu reproduzieren.

Ich habe zuerst angefangen, überall im Collector startLocation mit startLocationLat, etc. zu ersetzen, bis ich gemerkt habe, dass das ja auch auf dem EventBus benutzt wird und ich somit nicht weiß, ob das etwas "hinter" dem EventBus zerstört.

Um das trotzdem kompatibel mit dem Client zu machen, findest du hier im PR eine minimale Änderung damit die API erst einmal kompatibel ist, ohne dass ich am EventBus Format etwas machen muss:

Die lat/lon/time HeaderParts werden einfach zu dem "lat: lat, lon: lon, time: time" im MeasurementHandler zusammengesetzt und somit brauche ich den Rest dahinter vorerst nicht ändern.