### PR TITLE
Add runs-on to docker publish workflow

### DIFF
--- a/.github/workflows/docker_publish_tags.yml
+++ b/.github/workflows/docker_publish_tags.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   build:
 
+    runs-on: ubuntu-latest
+
     steps:
     - uses: actions/checkout@v1
     - name: Set up JDK 1.8


### PR DESCRIPTION
A very small fix to the docker publish Github Actions workflow