### PR TITLE
[VIC-239] Fix entrypoint script salt injection

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,7 +29,7 @@ echo "Loading public key for JWT from: $JWT_PUBLIC_KEY_FILE_PATH"
 
 if [ -n "$SALT" ]; then
 	SALT_PARAMETER=",\"salt\":\"$SALT\""
-elif [ -n "$SALT_FILE" ]; then
+elif [ -f "$SALT_FILE" ]; then
 	SALT_PARAMETER=",\"salt.path\":\"$SALT_FILE\""
 else
 	SALT_PARAMETER=",\"salt\":\"cyface-salt\""

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,9 +27,9 @@ fi
 echo "Loading private key for JWT from: $JWT_PRIVATE_KEY_FILE_PATH"
 echo "Loading public key for JWT from: $JWT_PUBLIC_KEY_FILE_PATH"
 
-if [ -z $SALT ]; then
+if [ -n "$SALT" ]; then
 	SALT_PARAMETER=",\"salt\":\"$SALT\""
-elif [ -f $SALT_FILE ]; then
+elif [ -n "$SALT_FILE" ]; then
 	SALT_PARAMETER=",\"salt.path\":\"$SALT_FILE\""
 else
 	SALT_PARAMETER=",\"salt\":\"cyface-salt\""


### PR DESCRIPTION
Before the fix:
$ ./test.sh
,"salt":""
$ SALT_FILE=/path/salt ./test.sh
,"salt":""
$ SALT=curcuma ./test.sh
,"salt.path":""

After the fix:
$ ./test.sh
,"salt":"cyface-salt"
$ SALT_FILE=/path/salt ./test.sh
,"salt.path":"/path/salt"
$ SALT=sugar ./test.sh
,"salt":"sugar"

Which explains what you can see why you log into a server and check:
```
.../cyface$ cat logs/collector.log | grep salt
```