### PR TITLE
Task/leip 69 rename master to main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - main
-      - 'release/**'
+      - 'release**'
   pull_request:
     branches:
       - main
-      - 'release/**'
+      - 'release**'
 
 jobs:
   build:


### PR DESCRIPTION
Ich habe gerade noch gemerkt, dass du für das Release einen PR erstellst:

into `release` from `release-4.0.9_CY-5554`

Das löst dann kein CI-Build aus, weil derzeit das Format `release/1.X...`war

Daher die Änderung zu `release**`