### PR TITLE
Task/cy 5592 fix ci release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - main
-      - 'release/**'
+      - 'release**'
   pull_request:
     branches:
       - main
-      - 'release/**'
+      - 'release**'
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - main
-      - 'release**'
+      - release
   pull_request:
     branches:
       - main
-      - 'release**'
+      - release
 
 jobs:
   build:

--- a/.github/workflows/docker_publish_tags.yml
+++ b/.github/workflows/docker_publish_tags.yml
@@ -2,9 +2,6 @@ name: Cyface Data Collector
 
 on: 
   push:
-    branches: 
-      - dev
-      - master
     tags:
       - '*'
 


### PR DESCRIPTION
There was a PR before #69 which we forgot ...

Here is a new PR. I don't think we need to publish Docker Images for each commit on master, do we?

I'll port the publish process to Github Packages as in our other backend components soon.

It makes sense not to publish Images as we don't need as this uses resources needlessly and also costs additional money (more storage required).