### PR TITLE
[DAT-970] Check if user account is activated

### DIFF
--- a/executables/collector/src/main/resources/webroot/api/v3/openapi.yml
+++ b/executables/collector/src/main/resources/webroot/api/v3/openapi.yml
@@ -2,7 +2,7 @@ openapi: 3.0.2
 info:
   title: Cyface Data Collector
   description: This is a Cyface data collection endpoint, that receives traffic data from Cyface measurement devices, and stores them for further processing.
-  version: 6.0.0
+  version: 6.2.0
   
 servers:
   - url: /api/v3
@@ -55,6 +55,8 @@ paths:
                 minimum: 0
         '401':
           description: The provided credentials were not correct
+        '428':
+          description: The user account is not activated.
         '429':
           description: Too many requests in short succession
             

--- a/libs/api-test-environment/src/main/java/de/cyface/apitestutils/ApiServer.java
+++ b/libs/api-test-environment/src/main/java/de/cyface/apitestutils/ApiServer.java
@@ -21,6 +21,8 @@ package de.cyface.apitestutils;
 import java.io.IOException;
 import java.net.ServerSocket;
 
+import org.apache.commons.lang3.Validate;
+
 import de.cyface.api.Parameter;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.DeploymentOptions;
@@ -33,7 +35,6 @@ import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.junit5.VertxTestContext;
-import org.apache.commons.lang3.Validate;
 
 /**
  * A class providing capabilities for tests to communicate with a Cyface Data server.
@@ -79,6 +80,23 @@ public final class ApiServer {
      */
     public void start(final Vertx vertx, final VertxTestContext testContext, final TestMongoDatabase mongoDatabase,
             final String verticleClassName, final Handler<AsyncResult<WebClient>> resultHandler) throws IOException {
+        start(vertx, testContext, mongoDatabase, verticleClassName, new JsonObject(), resultHandler);
+    }
+
+    /**
+     * Starts a test Cyface Data server and creates a Vert.x <code>WebClient</code> usable to access the API.
+     *
+     * @param vertx The <code>Vertx</code> instance to start and access the server
+     * @param testContext The <code>TestContext</code> to create a new Server and <code>WebClient</code>
+     * @param mongoDatabase The Mongo database to store the test data to
+     * @param resultHandler The handler called after this server has finished starting
+     * @param verticleClassName The name of the {@code ApiVerticle} to deploy
+     * @param config A {@code JsonObject} which contains custom config parameters to be used when deploying the verticle
+     * @throws IOException If the server port could not be opened
+     */
+    public void start(final Vertx vertx, final VertxTestContext testContext, final TestMongoDatabase mongoDatabase,
+            final String verticleClassName, final JsonObject config,
+            final Handler<AsyncResult<WebClient>> resultHandler) throws IOException {
 
         final ServerSocket socket = new ServerSocket(0);
         port = socket.getLocalPort();
@@ -86,7 +104,7 @@ public final class ApiServer {
 
         final var privateTestKey = this.getClass().getResource("/private_key.pem");
         final var publicTestKey = this.getClass().getResource("/public.pem");
-        final JsonObject config = new JsonObject().put(Parameter.MONGO_DATA_DB.key(), mongoDatabase.config())
+        config.put(Parameter.MONGO_DATA_DB.key(), mongoDatabase.config())
                 .put(Parameter.MONGO_USER_DB.key(), mongoDatabase.config())
                 .put(Parameter.HTTP_PORT.key(), port)
                 .put(Parameter.JWT_PRIVATE_KEY_FILE_PATH.key(), Validate.notNull(privateTestKey).getFile())

--- a/libs/api/src/main/java/de/cyface/api/AuthenticationFailureHandler.java
+++ b/libs/api/src/main/java/de/cyface/api/AuthenticationFailureHandler.java
@@ -18,10 +18,11 @@
  */
 package de.cyface.api;
 
-import io.vertx.core.Handler;
-import io.vertx.ext.web.RoutingContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
 
 /**
  * Handlers failures occurring during authentication and makes sure 401 is returned as HTTP status code on failed
@@ -43,12 +44,14 @@ public final class AuthenticationFailureHandler implements Handler<RoutingContex
         LOGGER.error("Received failure " + context.failed());
         LOGGER.error("Reason", context.failure());
 
-        final boolean closed = context.response().closed();
-        final boolean ended = context.response().ended();
+        final var response = context.response();
+        final boolean closed = response.closed();
+        final boolean ended = response.ended();
+        final var errorCode = context.statusCode();
         if (!closed && !ended) {
-            LOGGER.error("Failing authentication request with 401 since response was closed: {}, ended: {}", closed,
-                    ended);
-            context.response().setStatusCode(401).end();
+            LOGGER.error("Failing authentication request with {} since response was closed: {}, ended: {}", errorCode,
+                    closed, ended);
+            context.response().setStatusCode(errorCode).end();
         }
     }
 }

--- a/libs/api/src/test/java/de/cyface/api/AuthenticatorTest.java
+++ b/libs/api/src/test/java/de/cyface/api/AuthenticatorTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 Cyface GmbH
+ *
+ * This file is part of the Cyface Data Collector.
+ *
+ * The Cyface Data Collector is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Cyface Data Collector is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Cyface Data Collector. If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.cyface.api;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.jwt.JWTAuth;
+import io.vertx.ext.auth.mongo.MongoAuthentication;
+import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * This class checks the inner workings of the {@link Authenticator}.
+ *
+ * @author Armin Schnabel
+ * @since 6.2.0
+ */
+@SuppressWarnings({"SpellCheckingInspection"})
+public class AuthenticatorTest {
+
+    /**
+     * Only self-registered accounts need to be activated and, thus, a missing "activated" field counts as activated.
+     */
+    @Test
+    void testActivated() {
+        // Arrange
+        final var registeredPrincipal = new JsonObject().put("username", "guest").put("activated", false);
+        final var activatedPrincipal = new JsonObject().put("username", "guest").put("activated", true);
+        final var createdPrincipal = new JsonObject().put("username", "guest");
+
+        // Act
+        final var registeredResult = Authenticator.activated(registeredPrincipal);
+        final var activatedResult = Authenticator.activated(activatedPrincipal);
+        final var createdResult = Authenticator.activated(createdPrincipal);
+
+        // Assert
+        assertThat("Check activation", registeredResult, is(equalTo(false)));
+        assertThat("Check activation", activatedResult, is(equalTo(true)));
+        assertThat("Check activation", createdResult, is(equalTo(true)));
+    }
+}


### PR DESCRIPTION
Pass through error codeUntil now all accounts where able to authenticate.

Now as users can register themselves, we need to check if there is a `activated` field, and if so, if it's true.

This way we're kind of compatible to the accounts which were and are generated by administrator - which don't have an activated field.