### PR TITLE
[DAT-1121] Add libs/api/Authorizer handler and -/Role model

### DIFF
--- a/executables/collector/src/main/java/de/cyface/collector/verticle/CollectorApiVerticle.java
+++ b/executables/collector/src/main/java/de/cyface/collector/verticle/CollectorApiVerticle.java
@@ -173,12 +173,14 @@ public final class CollectorApiVerticle extends AbstractVerticle {
                 final var hasher = new Hasher(HashingStrategy.load(),
                         salt.getBytes(StandardCharsets.UTF_8));
                 final var userCreationHandler = new UserCreationHandler(userClient, "user", hasher);
-                userCreationHandler.createUser(adminUsername, adminPassword, ADMIN_ROLE, success -> {
-                    LOGGER.info("Identifier of new user id: {}", success);
+                final var userCreation = userCreationHandler.createUser(adminUsername, adminPassword, ADMIN_ROLE);
+                userCreation.onSuccess(id -> {
+                    LOGGER.info("Identifier of new user id: {}", id);
                     promise.complete();
-                }, failure -> {
+                });
+                userCreation.onFailure(e -> {
                     LOGGER.error("Unable to create default user!");
-                    promise.fail(failure);
+                    promise.fail(e);
                 });
             } else {
                 promise.complete();

--- a/libs/api-test-environment/src/main/java/de/cyface/apitestutils/ApiServer.java
+++ b/libs/api-test-environment/src/main/java/de/cyface/apitestutils/ApiServer.java
@@ -138,14 +138,12 @@ public final class ApiServer {
      * @param client The Vert.x <code>WebClient</code> to use
      * @param endpoint The service endpoint to call to get some data
      * @param testContext The <code>VertxTextContext</code> provided by the current test case
-     * @param groupName The user group to export data for
      * @param format A field to identify the requested format, such as 'csv' or 'json'.
      * @param resultHandler A handler provided with the result of the get request
      */
     @SuppressWarnings("unused") // Part of the API
     public void get(final WebClient client, final String endpoint, final VertxTestContext testContext,
-            final String groupName, final String format,
-            final Handler<AsyncResult<HttpResponse<Buffer>>> resultHandler) {
+            final String format, final Handler<AsyncResult<HttpResponse<Buffer>>> resultHandler) {
         authenticate(client, testContext.succeeding(response -> {
 
             final String authToken = response.getHeader("Authorization");
@@ -153,7 +151,6 @@ public final class ApiServer {
             if (response.statusCode() == 200 && authToken != null) {
                 final HttpRequest<Buffer> builder = client.get(port(), HTTP_HOST, httpEndpoint + endpoint);
                 builder.putHeader("Authorization", "Bearer " + authToken);
-                builder.putHeader("group", groupName);
                 builder.putHeader("format", format);
                 builder.send(resultHandler);
             } else {

--- a/libs/api-test-environment/src/main/java/de/cyface/apitestutils/TestEnvironment.java
+++ b/libs/api-test-environment/src/main/java/de/cyface/apitestutils/TestEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Cyface GmbH
+ * Copyright 2020-2022 Cyface GmbH
  *
  * This file is part of the Cyface Data Collector.
  *
@@ -37,7 +37,7 @@ import io.vertx.junit5.VertxTestContext;
  * @author Klemens Muthmann
  * @author Armin Schnabel
  * @version 2.1.0
- * @since 1.0.0
+ * @since 1.0.1
  */
 public final class TestEnvironment {
     /**

--- a/libs/api-test-environment/src/main/java/de/cyface/apitestutils/TestEnvironment.java
+++ b/libs/api-test-environment/src/main/java/de/cyface/apitestutils/TestEnvironment.java
@@ -113,7 +113,7 @@ public final class TestEnvironment {
                     this.webClient = webClient;
 
                     // Set up a Mongo client to access the database
-                    JsonObject mongoDbConfiguration = testMongoDatabase.config();
+                    final var mongoDbConfiguration = testMongoDatabase.config();
                     this.mongoClient = EndpointConfig.createSharedMongoClient(vertx, mongoDbConfiguration);
 
                     resultHandler.handle(Future.succeededFuture());

--- a/libs/api-test-environment/src/main/java/de/cyface/apitestutils/fixture/user/TestUser.java
+++ b/libs/api-test-environment/src/main/java/de/cyface/apitestutils/fixture/user/TestUser.java
@@ -111,7 +111,7 @@ public abstract class TestUser implements MongoTestData {
     }
 
     /**
-     * @return The hased and salted password of that user, as it would be present in the database.
+     * @return The hashed and salted password of that user, as it would be present in the database.
      */
     protected String getHashedPassword() {
         final var salt = "cyface-salt";

--- a/libs/api-test-environment/src/main/java/de/cyface/apitestutils/fixture/user/TestUser.java
+++ b/libs/api-test-environment/src/main/java/de/cyface/apitestutils/fixture/user/TestUser.java
@@ -99,7 +99,7 @@ public abstract class TestUser implements MongoTestData {
     /**
      * @return The name of the user to be created.
      */
-    protected String getUsername() {
+    public String getUsername() {
         return username;
     }
 

--- a/libs/api/build.gradle
+++ b/libs/api/build.gradle
@@ -7,4 +7,9 @@ dependencies {
   // Authentication
   implementation "io.vertx:vertx-auth-mongo:$vertxVersion" // DatabaseUtils
   implementation "io.vertx:vertx-auth-jwt:$vertxVersion" // Api
+
+  // Test Dependencies
+  testImplementation "io.vertx:vertx-junit5:$vertxVersion"
+  testImplementation "org.junit.jupiter:junit-jupiter:$junitVersion"
+  implementation "org.hamcrest:hamcrest:$hamcrestVersion"
 }

--- a/libs/api/build.gradle
+++ b/libs/api/build.gradle
@@ -1,3 +1,29 @@
+/*
+ * Copyright 2021-2022 Cyface GmbH
+ *
+ * This file is part of the Cyface Data Collector.
+ *
+ *  The Cyface Data Collector is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The Cyface Data Collector is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with the Cyface Data Collector.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * The build gradle file for the Cyface Data Collector.
+ *
+ * @author Klemens Muthmann
+ * @author Armin Schnabel
+ * @version 1.0.0
+ * @since 5.3.0
+ */
 dependencies {
   implementation "de.cyface:model:$cyfaceSerializationVersion"
 

--- a/libs/api/src/main/java/de/cyface/api/Authenticator.java
+++ b/libs/api/src/main/java/de/cyface/api/Authenticator.java
@@ -23,16 +23,13 @@ import static io.vertx.ext.auth.impl.jose.JWS.RS256;
 import java.util.Collections;
 import java.util.Objects;
 
-import io.vertx.core.impl.future.SucceededFuture;
-import io.vertx.core.json.JsonObject;
-import io.vertx.ext.auth.User;
-import io.vertx.ext.auth.impl.UserImpl;
 import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.vertx.core.Handler;
 import io.vertx.core.json.DecodeException;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.JWTOptions;
 import io.vertx.ext.auth.jwt.JWTAuth;
 import io.vertx.ext.auth.mongo.MongoAuthentication;
@@ -165,7 +162,7 @@ public final class Authenticator implements Handler<RoutingContext> {
      * @return {@code true} if the user account is activated
      */
     static boolean activated(final JsonObject principal) {
-        return  !principal.containsKey("activated") || principal.getBoolean("activated");
+        return !principal.containsKey("activated") || principal.getBoolean("activated");
     }
 
     /**

--- a/libs/api/src/main/java/de/cyface/api/Authenticator.java
+++ b/libs/api/src/main/java/de/cyface/api/Authenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 Cyface GmbH
+ * Copyright 2018-2022 Cyface GmbH
  *
  * This file is part of the Cyface Data Collector.
  *
@@ -48,7 +48,7 @@ import io.vertx.ext.web.handler.LoggerHandler;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 4.0.0
+ * @version 4.0.1
  * @since 2.0.0
  */
 public final class Authenticator implements Handler<RoutingContext> {

--- a/libs/api/src/main/java/de/cyface/api/Authorizer.java
+++ b/libs/api/src/main/java/de/cyface/api/Authorizer.java
@@ -35,7 +35,6 @@ import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.mongo.MongoAuthentication;
 import io.vertx.ext.mongo.MongoClient;
 import io.vertx.ext.web.RoutingContext;

--- a/libs/api/src/main/java/de/cyface/api/Authorizer.java
+++ b/libs/api/src/main/java/de/cyface/api/Authorizer.java
@@ -135,6 +135,8 @@ public abstract class Authorizer implements Handler<RoutingContext> {
      * <p>
      * If the user holds a {@link DatabaseConstants#GROUP_MANAGER_ROLE_SUFFIX} role, identifying it as the manager of
      * that group, all users of that group are loaded from the user collection.
+     * <p>
+     * This method is only public because of the `backend/AuthorizationTest`, see last comment on CY-5720.
      *
      * @param principal The principal object of the authenticated {@code User} which requests user data
      * @return The usernames of the users which the {@code user} can access
@@ -168,6 +170,8 @@ public abstract class Authorizer implements Handler<RoutingContext> {
 
     /**
      * Loads all users a specific group manager can access.
+     * <p>
+     * This method is only public because of the `backend/AuthorizationTest`, see last comment on CY-5720.
      *
      * @param groupManager The {@code Role} group manager to load the users for
      * @return The usernames of the users which the {@code groupManager} can access

--- a/libs/api/src/main/java/de/cyface/api/Authorizer.java
+++ b/libs/api/src/main/java/de/cyface/api/Authorizer.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2019-2022 Cyface GmbH
+ *
+ * This file is part of the Cyface Data Collector.
+ *
+ * The Cyface Data Collector is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Cyface Data Collector is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Cyface Data Collector. If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.cyface.api;
+
+import static io.vertx.ext.auth.mongo.MongoAuthorization.DEFAULT_ROLE_FIELD;
+import static io.vertx.ext.auth.mongo.MongoAuthorization.DEFAULT_USERNAME_FIELD;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.Validate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import de.cyface.api.model.Role;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.Promise;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.User;
+import io.vertx.ext.auth.mongo.MongoAuthentication;
+import io.vertx.ext.mongo.MongoClient;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Abstract base class for all requests to an endpoint which requires authorization.
+ * <p>
+ * This class ensures that such requests are properly authorized.
+ *
+ * @author Armin Schnabel
+ * @version 1.0.0
+ * @since 6.4.0
+ */
+public abstract class Authorizer implements Handler<RoutingContext> {
+
+    /**
+     * The logger for objects of this class. You can change its configuration by adapting the values in
+     * <code>src/main/resources/logback.xml</code>.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(Authorizer.class);
+    /**
+     * An auth provider used by this server to authenticate against the Mongo user database
+     */
+    private final MongoAuthentication authProvider;
+    /**
+     * The database to check which users a {@code manager} user has access to.
+     */
+    private final MongoClient mongoUserDatabase;
+
+    /**
+     * Creates a new completely initialized instance of this class with access to all required authentication
+     * information to authorize a request and fetch the correct data.
+     *
+     * @param authProvider An auth provider used by this server to authenticate against the Mongo user database
+     * @param mongoUserDatabase The Mongo user database containing all information about users
+     */
+    public Authorizer(final MongoAuthentication authProvider, final MongoClient mongoUserDatabase) {
+        Validate.notNull(authProvider);
+        Validate.notNull(mongoUserDatabase);
+
+        this.authProvider = authProvider;
+        this.mongoUserDatabase = mongoUserDatabase;
+    }
+
+    @Override
+    public void handle(final RoutingContext context) {
+        try {
+            LOGGER.info("Received new request.");
+            final var request = context.request();
+            final var headers = request.headers();
+            LOGGER.debug("Request headers: {}", headers);
+
+            // Check authorization
+            final var principal = context.user().principal();
+            final var username = principal.getString(DEFAULT_USERNAME_FIELD);
+            final var authentication = authProvider.authenticate(principal);
+            authentication.onSuccess(user -> {
+                final var loadUsers = loadAccessibleUsers(user.principal());
+                loadUsers.onSuccess(accessibleUsers -> {
+                    LOGGER.trace("Export request for {} authorized to access users {}", username, accessibleUsers);
+                    handleAuthorizedRequest(context, accessibleUsers, headers);
+                });
+                loadUsers.onFailure(e -> {
+                    LOGGER.error("Loading accessible users failed for user {}", username, e);
+                    context.fail(500);
+                });
+            });
+            authentication.onFailure(e -> {
+                LOGGER.error("Authorization failed for user {}!", username);
+                context.fail(401, e);
+            });
+        } catch (final NumberFormatException e) {
+            LOGGER.error("Data was not parsable!");
+            context.fail(422, e);
+        }
+    }
+
+    /**
+     * This is the method that should be implemented by subclasses to carry out the business logic on an authorized
+     * request.
+     *
+     * @param ctx Vert.x request context
+     * @param usernames A list of usernames for which the request is authorized to export data
+     * @param header the header of the request which may contain parameters required to process the request.
+     */
+    protected abstract void handleAuthorizedRequest(final RoutingContext ctx, final List<String> usernames,
+            final MultiMap header);
+
+    /**
+     * Loads all users which the authenticated {@code User} can access.
+     * <p>
+     * If the user is not a group manager, only the user itself is returned.
+     * <p>
+     * If the user holds a {@link DatabaseConstants#GROUP_MANAGER_ROLE_SUFFIX} role, identifying it as the manager of
+     * that group, all users of that group are loaded from the user collection.
+     *
+     * @param principal The principal object of the authenticated {@code User} which requests user data
+     * @return The usernames of the users which the {@code user} can access
+     */
+    protected Future<List<String>> loadAccessibleUsers(final JsonObject principal) {
+
+        final var roles = principal.getJsonArray(DEFAULT_ROLE_FIELD).stream().map(r -> new Role((String)r)).collect(Collectors.toList());
+        final var managerRoles = roles.stream().filter(r -> r.getType().equals(Role.Type.GROUP_MANAGER))
+                .collect(Collectors.toList());
+        final var username = Validate.notEmpty(principal.getString(DEFAULT_USERNAME_FIELD));
+
+        // Guest users and group users can only access their own account
+        if (managerRoles.isEmpty()) {
+            return Future.succeededFuture(Collections.singletonList(username));
+        } else if (managerRoles.size() > 1) {
+            return Future.failedFuture(new IllegalArgumentException(
+                    String.format("User %s is manager of more than one group.", username)));
+        } else {
+            final var groupManager = managerRoles.get(0);
+            return loadAccessibleUsers(groupManager);
+        }
+    }
+
+    /**
+     * Loads all users a specific group manager can access.
+     *
+     * @param groupManager The {@code Role} group manager to load the users for
+     * @return The usernames of the users which the {@code groupManager} can access
+     */
+    public Future<List<String>> loadAccessibleUsers(final Role groupManager) {
+        Validate.isTrue(groupManager.getType().equals(Role.Type.GROUP_MANAGER));
+        Validate.notEmpty(groupManager.getGroup());
+
+        final Promise<List<String>> promise = Promise.promise();
+        final var future = promise.future();
+        final var groupUsersRole = groupManager.getGroup() + DatabaseConstants.USER_GROUP_ROLE_SUFFIX;
+        mongoUserDatabase.find(DatabaseConstants.COLLECTION_USER,
+                new JsonObject().put(DEFAULT_ROLE_FIELD, groupUsersRole),
+                mongoResult -> {
+                    if (mongoResult.succeeded()) {
+                        final var users = mongoResult.result();
+                        final var userNames = users.parallelStream()
+                                .map(groupUser -> groupUser.getString(DEFAULT_USERNAME_FIELD))
+                                .collect(Collectors.toList());
+                        promise.complete(userNames);
+                    } else {
+                        promise.fail(mongoResult.cause());
+                    }
+                });
+        return future;
+    }
+
+    @SuppressWarnings("unused") // API
+    public MongoAuthentication getAuthProvider() {
+        return authProvider;
+    }
+
+    public MongoClient getMongoUserDatabase() {
+        return mongoUserDatabase;
+    }
+}

--- a/libs/api/src/main/java/de/cyface/api/DatabaseConstants.java
+++ b/libs/api/src/main/java/de/cyface/api/DatabaseConstants.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019-2022 Cyface GmbH
+ *
+ * This file is part of the Cyface Data Collector.
+ *
+ * The Cyface Data Collector is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Cyface Data Collector is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Cyface Data Collector. If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.cyface.api;
+
+/**
+ * Constants used in the database containing the compressed serialized data received from clients.
+ *
+ * @author Armin Schnabel
+ * @version 1.3.0
+ * @since 6.4.0
+ */
+public final class DatabaseConstants {
+
+    /**
+     * The database `roles` entry for users who signed up themselves and are not part of a user group.
+     */
+    public static final String GUEST_ROLE = "guest";
+    /**
+     * The prefix for user roles which defines a user with "manager" permissions.
+     * <p>
+     * The current semantic of the manager role is the following:
+     * The users with the role "myGroup_manager" can access data of all users with role
+     * "myGroup"+{@code #USER_GROUP_ROLE_PREFIX}
+     */
+    public static final String GROUP_MANAGER_ROLE_SUFFIX = "_manager";
+    /**
+     * The prefix for user roles which define a user "group" as there is no such thing in the vertx mongo auth provider.
+     * <p>
+     * The current semantic of the user role is the following:
+     * The user data of all users with the role "myGroup_user" can be accessed by users with role
+     * "myGroup"+{@code #GROUP_MANAGER_ROLE_PREFIX}
+     */
+    public static final String USER_GROUP_ROLE_SUFFIX = "_user";
+    /**
+     * The database collection name.
+     */
+    public static final String COLLECTION_USER = "user";
+}

--- a/libs/api/src/main/java/de/cyface/api/MeasurementIterator.java
+++ b/libs/api/src/main/java/de/cyface/api/MeasurementIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Cyface GmbH
+ * Copyright 2021-2022 Cyface GmbH
  *
  * This file is part of the Cyface Data Collector.
  *
@@ -50,6 +50,7 @@ import io.vertx.core.streams.ReadStream;
  *
  * @author Armin Schnabel
  * @since 6.0.0
+ * @version 1.0.0
  */
 final public class MeasurementIterator implements Iterator<Future<Measurement>>, Handler<JsonObject> {
 

--- a/libs/api/src/main/java/de/cyface/api/MeasurementIterator.java
+++ b/libs/api/src/main/java/de/cyface/api/MeasurementIterator.java
@@ -165,6 +165,7 @@ final public class MeasurementIterator implements Iterator<Future<Measurement>>,
      * Loads the next measurement until there is no measurement on this {@link MeasurementIterator}.
      *
      * @param writeHandler The handler which is called when a measurement is loaded.
+     * @param separationHandler The handler which is called between measurements, e.g. to add separators in the output
      * @param endHandler The handler which is called after the last measurement was loaded.
      * @param failureHandler The handler which is called upon errors.
      */

--- a/libs/api/src/main/java/de/cyface/api/MongoAuthHandler.java
+++ b/libs/api/src/main/java/de/cyface/api/MongoAuthHandler.java
@@ -94,20 +94,24 @@ public final class MongoAuthHandler implements Handler<RoutingContext> {
                 }
             }
             authProvider.authenticate(user.principal(), r -> {
-                // As in `SessionHandlerImpl.handle(RoutingContext)`
-                final var upgraded = request.headers().contains(HttpHeaders.UPGRADE, HttpHeaders.WEBSOCKET, true);
-                if (pauseAndResume && !parseEnded && !upgraded) {
-                    request.resume();
-                }
+                try {
+                    // As in `SessionHandlerImpl.handle(RoutingContext)`
+                    final var upgraded = request.headers().contains(HttpHeaders.UPGRADE, HttpHeaders.WEBSOCKET, true);
+                    if (pauseAndResume && !parseEnded && !upgraded) {
+                        request.resume();
+                    }
 
-                if (!(r.succeeded())) {
-                    LOGGER.error("Authorization failed for user {}!", username);
-                    ctx.fail(UNAUTHORIZED);
-                    return;
-                }
+                    if (!(r.succeeded())) {
+                        LOGGER.error("Authorization failed for user {}!", username);
+                        ctx.fail(UNAUTHORIZED);
+                        return;
+                    }
 
-                LOGGER.trace("Request authorized for user {}", username);
-                ctx.next();
+                    LOGGER.trace("Request authorized for user {}", username);
+                    ctx.next();
+                } catch (Exception e) {
+                    ctx.fail(e);
+                }
             });
         } catch (final NumberFormatException e) {
             LOGGER.error("Data was not parsable!");

--- a/libs/api/src/main/java/de/cyface/api/model/Role.java
+++ b/libs/api/src/main/java/de/cyface/api/model/Role.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2022 Cyface GmbH
+ *
+ * This file is part of the Cyface Data Collector.
+ *
+ * The Cyface Data Collector is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Cyface Data Collector is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Cyface Data Collector. If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.cyface.api.model;
+
+import java.util.Objects;
+
+import org.apache.commons.lang3.Validate;
+
+import de.cyface.api.DatabaseConstants;
+
+/**
+ * This class represents a user role of a specific {@link Type}.
+ *
+ * @author Armin Schnabel
+ * @since 6.4.0
+ * @version 1.0.0
+ */
+public class Role {
+
+    /**
+     * The {@link Type} of this role.
+     */
+    private final Type type;
+    /**
+     * The group the user with that role is part of. {@code Null} if the users is a {@link Type#GUEST}.
+     */
+    private final String group;
+
+    /**
+     * Constructs a fully initialized instance of this class.
+     *
+     * @param type The {@link Type} of this role. Only {@link Type#GUEST} roles are allowed without group. Use
+     *            {@link Role(Type, String)} for other roles.
+     */
+    public Role(Type type) {
+        Validate.isTrue(type.equals(Type.GUEST), String.format("Guest role expected, but is: %s", type));
+        this.type = type;
+        this.group = null;
+    }
+
+    /**
+     * Constructs a fully initialized instance of this class.
+     *
+     * @param type The {@link Type} of this role.
+     * @param group The group the user with that role is part of. {@code Null} if the users is a {@link Type#GUEST}.
+     */
+    public Role(Type type, String group) {
+        if (type != Type.GUEST) {
+            Validate.notEmpty(group,
+                    String.format("Only guest users are not part of a user group but type is: %s", type));
+        }
+        this.group = group;
+        this.type = type;
+    }
+
+    /**
+     * Constructs a fully initialized instance of this class.
+     *
+     * @param databaseValue A role entry from the database.
+     */
+    public Role(final String databaseValue) {
+        final var isGuest = databaseValue.matches(Type.GUEST.getRegex());
+        final var isGroupUser = databaseValue.matches(Type.GROUP_USER.getRegex());
+        final var isGroupManager = databaseValue.matches(Type.GROUP_MANAGER.getRegex());
+        if (isGuest) {
+            this.type = Type.GUEST;
+            this.group = null;
+        } else if (isGroupUser) {
+            this.type = Type.GROUP_USER;
+            final var group = databaseValue.substring(0,
+                    databaseValue.length() - DatabaseConstants.USER_GROUP_ROLE_SUFFIX.length());
+            this.group = Validate.notEmpty(group);
+        } else if (isGroupManager) {
+            this.type = Type.GROUP_MANAGER;
+            final var group = databaseValue.substring(0,
+                    databaseValue.length() - DatabaseConstants.GROUP_MANAGER_ROLE_SUFFIX.length());
+            this.group = Validate.notEmpty(group);
+        } else {
+            throw new IllegalArgumentException(String.format("Unknown role format: %s", databaseValue));
+        }
+    }
+
+    /**
+     * @return The group the user with that role is part of. {@code Null} if the users is a {@link Type#GUEST}.
+     */
+    public String getGroup() {
+        return group;
+    }
+
+    /**
+     * @return The {@link Type} of this role.
+     */
+    public Type getType() {
+        return type;
+    }
+
+    @Override
+    public String toString() {
+        return "Role{" +
+                "type=" + type +
+                ", group='" + group + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Role role = (Role) o;
+        return type == role.type && Objects.equals(group, role.group);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, group);
+    }
+
+    /**
+     * The type of {@link Role}.
+     *
+     * @author Armin Schnabel
+     * @since 6.4.0
+     * @version 1.0.0
+     */
+    public enum Type {
+        /**
+         * A guest user who signed up himself and is not part of a user group.
+         */
+        GUEST(DatabaseConstants.GUEST_ROLE),
+        /**
+         * A group user who collects data for a group manager.
+         */
+        GROUP_USER("([a-z0-9\\-]{1,32})" + DatabaseConstants.USER_GROUP_ROLE_SUFFIX),
+        /**
+         * A group manager who can access all data of all users of its group.
+         */
+        GROUP_MANAGER("([a-z0-9\\-]{1,32})" + DatabaseConstants.GROUP_MANAGER_ROLE_SUFFIX);
+
+        /**
+         * The regex which represents this role type.
+         */
+        private final String regex;
+
+        /**
+         * Creates a new completely initialized multipart form attribute.
+         *
+         * @param regex The regex which represents this role type.
+         */
+        Type(final String regex) {
+            this.regex = regex;
+        }
+
+        /**
+         * @return The regex which represents this role type.
+         */
+        public String getRegex() {
+            return regex;
+        }
+    }
+}

--- a/libs/api/src/main/java/de/cyface/api/model/Role.java
+++ b/libs/api/src/main/java/de/cyface/api/model/Role.java
@@ -146,11 +146,11 @@ public class Role {
         /**
          * A group user who collects data for a group manager.
          */
-        GROUP_USER("([a-z0-9\\-]{1,32})" + DatabaseConstants.USER_GROUP_ROLE_SUFFIX),
+        GROUP_USER("([a-zA-Z0-9\\-]{1,32})" + DatabaseConstants.USER_GROUP_ROLE_SUFFIX),
         /**
          * A group manager who can access all data of all users of its group.
          */
-        GROUP_MANAGER("([a-z0-9\\-]{1,32})" + DatabaseConstants.GROUP_MANAGER_ROLE_SUFFIX);
+        GROUP_MANAGER("([a-zA-Z0-9\\-]{1,32})" + DatabaseConstants.GROUP_MANAGER_ROLE_SUFFIX);
 
         /**
          * The regex which represents this role type.

--- a/libs/api/src/test/java/de/cyface/api/AuthorizerTest.java
+++ b/libs/api/src/test/java/de/cyface/api/AuthorizerTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2022 Cyface GmbH
+ *
+ * This file is part of the Cyface Data Collector.
+ *
+ * The Cyface Data Collector is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Cyface Data Collector is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Cyface Data Collector. If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.cyface.api;
+
+import static io.vertx.ext.auth.mongo.MongoAuthorization.DEFAULT_ROLE_FIELD;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import de.cyface.api.model.Role;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.mongo.MongoAuthentication;
+import io.vertx.ext.mongo.MongoClient;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Tests that authorization of users belonging to different groups works as expected.
+ * <p>
+ * An integration test exists in `backend/exporter/AuthorizationTest` to avoid circular dependency.
+ *
+ * @author Armin Schnabel
+ * @version 1.0.0
+ * @since 6.4.0
+ */
+@ExtendWith(MockitoExtension.class)
+public class AuthorizerTest {
+
+    @Mock
+    MongoAuthentication mockProvider;
+    @Mock
+    MongoClient mockUserDatabase;
+
+    private final static String DEFAULT_USERNAME = "testUser";
+
+    @ParameterizedTest
+    @MethodSource("testParameters")
+    void testLoadAccessibleUsers_forUser_withUser(final TestParameters parameters) {
+        // Arrange
+        final var oocut = new TestAuthorizer(mockProvider, mockUserDatabase);
+        final var principal = new JsonObject();
+        principal.put("username", DEFAULT_USERNAME);
+        principal.put("roles", parameters.roles);
+
+        // Act
+        final var result = oocut.loadAccessibleUsers(principal).result();
+
+        // Assert
+        assertThat(result, is(equalTo(parameters.expectedResult)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("testManagerRoles")
+    void testLoadAccessibleUsers_forUser_withManager(final JsonArray roles) {
+        // Arrange
+        final var oocut = new TestAuthorizer(mockProvider, mockUserDatabase);
+        final var principal = new JsonObject();
+        principal.put("username", DEFAULT_USERNAME);
+        principal.put("roles", roles);
+        // noinspection unchecked
+        when(mockUserDatabase.find(ArgumentMatchers.any(String.class), ArgumentMatchers.any(JsonObject.class),
+                ArgumentMatchers.any(Handler.class))).thenReturn(mockUserDatabase);
+
+        // Act
+        oocut.loadAccessibleUsers(principal);
+
+        // Assert that the database is search for users of that project
+        // noinspection unchecked
+        verify(mockUserDatabase, times(1)).find(eq(DatabaseConstants.COLLECTION_USER),
+                eq(new JsonObject().put(DEFAULT_ROLE_FIELD, "project_user")), ArgumentMatchers.any(Handler.class));
+    }
+
+    @Test
+    void testLoadAccessibleUsers_forGroupManager() {
+        // Arrange
+        final var oocut = new TestAuthorizer(mockProvider, mockUserDatabase);
+        final var groupManager = new Role(Role.Type.GROUP_MANAGER, "project");
+        // noinspection unchecked
+        when(mockUserDatabase.find(ArgumentMatchers.any(String.class), ArgumentMatchers.any(JsonObject.class),
+                ArgumentMatchers.any(Handler.class))).thenReturn(mockUserDatabase);
+
+        // Act
+        oocut.loadAccessibleUsers(groupManager);
+
+        // Assert
+        // noinspection unchecked
+        verify(mockUserDatabase, times(1)).find(eq(DatabaseConstants.COLLECTION_USER),
+                eq(new JsonObject().put(DEFAULT_ROLE_FIELD, "project_user")), ArgumentMatchers.any(Handler.class));
+    }
+
+    @SuppressWarnings("unused")
+    static Stream<JsonArray> testManagerRoles() {
+        return Stream.of(
+                new JsonArray().add("project_manager"),
+                new JsonArray().add("project_user").add("project_manager"));
+    }
+
+    @SuppressWarnings("unused")
+    static Stream<TestParameters> testParameters() {
+        return Stream.of(
+                new TestParameters(new JsonArray().add("guest"), Collections.singletonList(DEFAULT_USERNAME)),
+                new TestParameters(new JsonArray().add("project_user"), Collections.singletonList(DEFAULT_USERNAME)));
+    }
+
+    private static class TestParameters {
+        JsonArray roles;
+        List<String> expectedResult;
+
+        public TestParameters(JsonArray roles, List<String> expectedResult) {
+            this.roles = roles;
+            this.expectedResult = expectedResult;
+        }
+    }
+
+    private static class TestAuthorizer extends Authorizer {
+
+        /**
+         * Creates a new completely initialized instance of this class with access to all required authentication
+         * information to authorize a request and fetch the correct data.
+         *
+         * @param authProvider An auth provider used by this server to authenticate against the Mongo user database
+         * @param mongoUserDatabase The Mongo user database containing all information about users
+         */
+        public TestAuthorizer(MongoAuthentication authProvider, MongoClient mongoUserDatabase) {
+            super(authProvider, mongoUserDatabase);
+        }
+
+        @Override
+        protected void handleAuthorizedRequest(RoutingContext ctx, List<String> usernames, MultiMap header) {
+            // Nothing to do
+        }
+    }
+}

--- a/libs/api/src/test/java/de/cyface/api/RoleTest.java
+++ b/libs/api/src/test/java/de/cyface/api/RoleTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2022 Cyface GmbH
+ *
+ * This file is part of the Cyface Data Collector.
+ *
+ * The Cyface Data Collector is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Cyface Data Collector is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Cyface Data Collector. If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.cyface.api;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import de.cyface.api.model.Role;
+
+/**
+ * Tests whether the roles constructions from database values works as expected.
+ *
+ * @author Armin Schnabel
+ * @version 1.0.0
+ * @since 6.4.0
+ */
+@SuppressWarnings({"SpellCheckingInspection"})
+public class RoleTest {
+
+    @ParameterizedTest
+    @MethodSource("testParameters")
+    void test_happyPath(final TestParameters parameters) {
+        // Arrange
+
+        // Act
+        final var oocut = new Role(parameters.databaseValue);
+
+        // Assert
+        assertThat(oocut, is(equalTo(parameters.expectedResult)));
+    }
+
+    @Test
+    void test_managerWithoutGroup_throwsException() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new Role("_manager"));
+    }
+
+    @Test
+    void test_groupWithoutType_throwsException() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new Role("project"));
+    }
+
+    @SuppressWarnings("unused")
+    static Stream<TestParameters> testParameters() {
+        return Stream.of(
+                new TestParameters("guest", new Role(Role.Type.GUEST, null)),
+                new TestParameters("project_user", new Role(Role.Type.GROUP_USER, "project")),
+                new TestParameters("project_manager", new Role(Role.Type.GROUP_MANAGER, "project")),
+                new TestParameters("pro-ject_manager", new Role(Role.Type.GROUP_MANAGER, "pro-ject")));
+    }
+
+    private static class TestParameters {
+        String databaseValue;
+        Role expectedResult;
+
+        public TestParameters(String databaseValue, Role expectedResult) {
+            this.databaseValue = databaseValue;
+            this.expectedResult = expectedResult;
+        }
+    }
+}

--- a/libs/api/src/test/java/de/cyface/api/RoleTest.java
+++ b/libs/api/src/test/java/de/cyface/api/RoleTest.java
@@ -69,7 +69,8 @@ public class RoleTest {
                 new TestParameters("guest", new Role(Role.Type.GUEST, null)),
                 new TestParameters("project_user", new Role(Role.Type.GROUP_USER, "project")),
                 new TestParameters("project_manager", new Role(Role.Type.GROUP_MANAGER, "project")),
-                new TestParameters("pro-ject_manager", new Role(Role.Type.GROUP_MANAGER, "pro-ject")));
+                new TestParameters("pro-ject_manager", new Role(Role.Type.GROUP_MANAGER, "pro-ject")),
+                new TestParameters("testGroup_manager", new Role(Role.Type.GROUP_MANAGER, "testGroup")));
     }
 
     private static class TestParameters {


### PR DESCRIPTION
This PR moves code from `backend.provider/.exporter.RequestHandler` to a new Class called `Authorizer` which can not handle all `roles`:
- `guest`
- `group_user`
- `group_manager`

I also added a model for `Role`.

The `backend` PR related to this PR is [here](https://github.com/cyface-de/backend/pull/200).