### PR TITLE
[DAT-1427] Allow raw v2 data in database

### DIFF
--- a/src/main/java/de/cyface/collector/handler/FailureHandler.java
+++ b/src/main/java/de/cyface/collector/handler/FailureHandler.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 Cyface GmbH
+ *
+ * This file is part of the Cyface Data Collector.
+ *
+ * The Cyface Data Collector is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Cyface Data Collector is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Cyface Data Collector. If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.cyface.collector.handler;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.impl.logging.Logger;
+import io.vertx.core.impl.logging.LoggerFactory;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.common.WebEnvironment;
+import io.vertx.ext.web.handler.impl.ErrorHandlerImpl;
+
+/**
+ * This custom {@code ErrorHandlerImpl} extension prints the stacktrace of exceptions from `ctx.fail(e)` in the console.
+ * <p>
+ * We cannot use `ErrorHandler.create(vertx, true)` as this prints stacktrace in the http response not the console.
+ *
+ * @author Armin Schnabel
+ * @version 1.0.0
+ * @since 6.10.1
+ */
+public class FailureHandler extends ErrorHandlerImpl {
+
+    /**
+     * The logger used for objects of this class. Configure it using <code>src/main/resources/logback.xml</code>.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(FailureHandler.class);
+
+    /**
+     * Constructs a fully initialized instance of this class.
+     *
+     * @param vertx The context required to read the {@code errorTemplateName} from the file system.
+     */
+    public FailureHandler(final Vertx vertx) {
+        super(vertx, DEFAULT_ERROR_HANDLER_TEMPLATE, WebEnvironment.development());
+    }
+
+    @Override
+    public void handle(final RoutingContext ctx) {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Headers:");
+            for (final var header : ctx.request().headers()) {
+                LOGGER.debug(String.format("%s: %s", header.getKey(), header.getValue()));
+            }
+        }
+
+        // Printing stacktrace to console is necessary to be able to debug exceptions which only occurs in production
+        if (ctx.failure() != null) {
+            final var request = ctx.request();
+            LOGGER.error(
+                    String.format("Stacktrace: %s %s %d", request.method(), request.absoluteURI(), ctx.statusCode()),
+                    ctx.failure());
+        }
+
+        // Respond to client with pretty error page
+        super.handle(ctx);
+    }
+}

--- a/src/main/java/de/cyface/collector/handler/PreRequestHandler.java
+++ b/src/main/java/de/cyface/collector/handler/PreRequestHandler.java
@@ -153,10 +153,7 @@ public class PreRequestHandler extends Authorizer {
                     query.put("metadata.deviceId", deviceId);
                     query.put("metadata.measurementId", measurementId);
                     final var findIds = gridFs.findIds(query);
-                    findIds.onFailure(failure -> {
-                        LOGGER.error(failure.getMessage(), failure);
-                        ctx.fail(500, failure);
-                    });
+                    findIds.onFailure(ctx::fail);
                     findIds.onSuccess(ids -> {
                         try {
                             if (ids.size() > 1) {
@@ -196,13 +193,11 @@ public class PreRequestHandler extends Authorizer {
                 }
             });
         } catch (final InvalidMetaData | Unparsable | IllegalSession | PayloadTooLarge e) {
-            LOGGER.error(e.getMessage(), e);
-            ctx.fail(ENTITY_UNPARSABLE);
+            ctx.fail(ENTITY_UNPARSABLE, e);
         } catch (SkipUpload e) {
-            LOGGER.debug(e.getMessage(), e);
             // Ask the client to skip the upload, e.g. b/c of geo-fencing, deprecated Binary, missing locations, ...
             // We can add information to the response body to distinguish different causes.
-            ctx.fail(PRECONDITION_FAILED);
+            ctx.fail(PRECONDITION_FAILED, e);
         }
     }
 

--- a/src/main/java/de/cyface/collector/handler/StatusHandler.java
+++ b/src/main/java/de/cyface/collector/handler/StatusHandler.java
@@ -149,24 +149,23 @@ public class StatusHandler implements Handler<RoutingContext> {
                                             ctx.fail(e);
                                         }
                                     });
-                                    loadProps.onFailure(e -> ctx.fail(500, e));
+                                    loadProps.onFailure(ctx::fail);
                                 } catch (RuntimeException e) {
                                     ctx.fail(e);
                                 }
                             });
-                            fileCheck.onFailure(e -> ctx.fail(500, e));
+                            fileCheck.onFailure(ctx::fail);
                         } catch (RuntimeException e) {
                             ctx.fail(e);
                         }
                     });
-                    findIds.onFailure(e -> ctx.fail(500, e));
+                    findIds.onFailure(ctx::fail);
                 } catch (RuntimeException e) {
                     ctx.fail(e);
                 }
             });
         } catch (InvalidMetaData e) {
-            LOGGER.error(e.getMessage(), e);
-            ctx.fail(ENTITY_UNPARSABLE);
+            ctx.fail(ENTITY_UNPARSABLE, e);
         }
     }
 }

--- a/src/main/java/de/cyface/collector/handler/UserCreationHandler.java
+++ b/src/main/java/de/cyface/collector/handler/UserCreationHandler.java
@@ -92,8 +92,8 @@ public final class UserCreationHandler implements Handler<RoutingContext> {
             event.response().setStatusCode(201).end();
         });
         userCreation.onFailure(e -> {
-            LOGGER.error(String.format("Unable to create user with id: %s", username), e);
-            event.fail(400);
+            LOGGER.error(String.format("Unable to create user with id: %s", username));
+            event.fail(400, e);
         });
     }
 

--- a/src/main/java/de/cyface/collector/verticle/CollectorApiVerticle.java
+++ b/src/main/java/de/cyface/collector/verticle/CollectorApiVerticle.java
@@ -18,16 +18,15 @@
  */
 package de.cyface.collector.verticle;
 
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
+import de.cyface.collector.handler.FailureHandler;
 import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import de.cyface.api.Authenticator;
-import de.cyface.api.FailureHandler;
 import de.cyface.api.Hasher;
 import de.cyface.api.Parameter;
 import de.cyface.collector.handler.PreRequestHandler;
@@ -90,9 +89,8 @@ public final class CollectorApiVerticle extends AbstractVerticle {
      * Creates a new completely initialized object of this class.
      *
      * @param salt The value to be used as encryption salt
-     * @throws IOException if key files are inaccessible
      */
-    public CollectorApiVerticle(final String salt) throws IOException {
+    public CollectorApiVerticle(final String salt) {
         super();
         this.salt = salt;
     }
@@ -209,7 +207,7 @@ public final class CollectorApiVerticle extends AbstractVerticle {
         setupApiRouter(apiRouter, config);
 
         // Setup unknown-resource handler
-        mainRouter.route("/*").last().handler(new FailureHandler());
+        mainRouter.route("/*").last().handler(new de.cyface.api.FailureHandler());
 
         return mainRouter;
     }
@@ -225,7 +223,7 @@ public final class CollectorApiVerticle extends AbstractVerticle {
         // Setup measurement routes
         final var preRequestHandler = new PreRequestHandler(config);
         final var measurementHandler = new de.cyface.collector.handler.MeasurementHandler(config);
-        final var failureHandler = ErrorHandler.create(vertx);
+        final var failureHandler = new FailureHandler(vertx);
         final var preRequestBodyHandler = BodyHandler.create().setBodyLimit(BYTES_IN_ONE_KILOBYTE);
 
         // Setup authentication

--- a/src/main/java/de/cyface/collector/verticle/CollectorApiVerticle.java
+++ b/src/main/java/de/cyface/collector/verticle/CollectorApiVerticle.java
@@ -110,6 +110,8 @@ public final class CollectorApiVerticle extends AbstractVerticle {
         // Create indices
         final var unique = new IndexOptions().unique(true);
         final var measurementIndex = new JsonObject().put("metadata.deviceId", 1).put("metadata.measurementId", 1);
+        // While the db stills contains `v2` data we allow 2 entries per did/mid: fileType:ccyfe & ccyf [DAT-1427]
+        measurementIndex.put("metadata.fileType", 1);
         final var measurementIndexCreation = config.getDatabase().createIndexWithOptions("fs.files",
                 measurementIndex, unique);
         final var userIndex = new JsonObject().put("username", 1);


### PR DESCRIPTION
As discussed, without this the collector does not start with our current databases which still contain raw V2 measurements.

I created a task to undo this after we drop support for raw V2 measurements: CY-6102