### PR TITLE
Fix Upload to Google Cloud

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,8 +28,6 @@ import java.net.URL
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 2.0.3
- * @since 1.0.0
  */
 buildscript {
   repositories {
@@ -87,7 +85,7 @@ kotlin {
   jvmToolchain(17)
 }
 
-val vertxVersion = "4.5.7"
+val vertxVersion = "4.5.8"
 val micrometerVersion = "1.10.6"
 val commonsLangVersion = "3.12.0"
 val logbackVersion = "1.4.14"
@@ -105,6 +103,8 @@ val flapdoodleVersion = "3.5.3" // major upgrade available
 val mockitoKotlinVersion = "4.1.0"
 val dokkaVersion = "1.9.10"
 val detektVersion = "1.23.1"
+val cyfaceSynchronizerVersion = "1.3.1"
+val testContainerVersion = "1.19.8"
 
 tasks.wrapper {
   gradleVersion = project.extra["gradleWrapperVersion"].toString()
@@ -158,7 +158,10 @@ dependencies {
   testImplementation("io.vertx:vertx-junit5:$vertxVersion")
   testImplementation("io.vertx:vertx-web-client:$vertxVersion")
   // This is required to run an embedded Mongo instance for integration testing.
+  // TODO: Switch to using testcontainers completely.
   testImplementation("de.flapdoodle.embed:de.flapdoodle.embed.mongo:$flapdoodleVersion")
+  testImplementation("de.cyface:uploader:$cyfaceSynchronizerVersion")
+  testImplementation("org.testcontainers:testcontainers:$testContainerVersion")
 
   // Required to create inline documentation
   dokkaHtmlPlugin("org.jetbrains.dokka:kotlin-as-java-plugin:$dokkaVersion")

--- a/src/main/kotlin/de/cyface/collector/storage/DataStorageService.kt
+++ b/src/main/kotlin/de/cyface/collector/storage/DataStorageService.kt
@@ -26,7 +26,7 @@ import de.cyface.collector.model.User
 import io.vertx.core.Future
 import io.vertx.core.Vertx
 import io.vertx.core.buffer.Buffer
-import io.vertx.core.streams.Pipe
+import io.vertx.core.streams.ReadStream
 import java.util.UUID
 
 /**
@@ -37,18 +37,17 @@ import java.util.UUID
  * and to ask for status information. After an upload is complete, the `uploadIdentifier` becomes invalid.
  *
  * @author Klemens Muthmann
- * @version 3.0.0
  */
 interface DataStorageService {
     /**
-     * Stores the data provided via the `pipe`.
+     * Stores the data provided via `sourceData`.
      *
-     * @param pipe A Vert.x `Pipe` with the data to upload.
+     * @param sourceData A Vert.x `ReadStream` with the data to upload.
      * @param uploadMetaData Information required to store the uploaded data properly.
      * @return A `Future` providing the ``Status`` of the upload, when it has finished.
      */
     fun store(
-        pipe: Pipe<Buffer>,
+        sourceData: ReadStream<Buffer>,
         uploadMetaData: UploadMetaData
     ): Future<Status>
 
@@ -95,7 +94,6 @@ interface DataStorageService {
  * A class summarizing the parameters required for data storage in addition to the raw data.
  *
  * @author Klemens Muthmann
- * @version 1.0.0
  * @property user The user who took the measurement.
  * @property contentRange The content range of the uploaded data as provided by the content-range HTTP header.
  * @property uploadIdentifier The cluster wide unique identifier of the upload.

--- a/src/main/kotlin/de/cyface/collector/storage/cloud/GoogleCloudStorage.kt
+++ b/src/main/kotlin/de/cyface/collector/storage/cloud/GoogleCloudStorage.kt
@@ -49,7 +49,6 @@ import java.util.UUID
  * previously present data.
  *
  * @author Klemens Muthmann
- * @version 1.1.1
  * @property credentials A Google Cloud credentials instance. For information on how to acquire such an instance see
  * the [Google Cloud documentation](https://github.com/googleapis/google-auth-library-java/blob/040acefec507f419f6e4ec4eab9645a6e3888a15/samples/snippets/src/main/java/AuthenticateExplicit.java).
  * @property projectIdentifier The name of the Google Cloud project to upload the data to.

--- a/src/main/kotlin/de/cyface/collector/storage/local/FileSystemStorageService.kt
+++ b/src/main/kotlin/de/cyface/collector/storage/local/FileSystemStorageService.kt
@@ -25,7 +25,7 @@ import de.cyface.collector.storage.UploadMetaData
 import io.vertx.core.Future
 import io.vertx.core.Vertx
 import io.vertx.core.buffer.Buffer
-import io.vertx.core.streams.Pipe
+import io.vertx.core.streams.ReadStream
 import java.util.UUID
 
 /**
@@ -41,7 +41,7 @@ import java.util.UUID
 class FileSystemStorageService(val vertx: Vertx) : DataStorageService {
 
     override fun store(
-        pipe: Pipe<Buffer>,
+        sourceData: ReadStream<Buffer>,
         uploadMetaData: UploadMetaData
     ): Future<Status> {
         @Suppress("UnusedPrivateMember", "UNUSED_VARIABLE")

--- a/src/test/kotlin/de/cyface/collector/handler/MeasurementHandlerTest.kt
+++ b/src/test/kotlin/de/cyface/collector/handler/MeasurementHandlerTest.kt
@@ -29,7 +29,7 @@ import io.vertx.core.MultiMap
 import io.vertx.core.buffer.Buffer
 import io.vertx.core.http.HttpServerRequest
 import io.vertx.core.http.HttpServerResponse
-import io.vertx.core.streams.Pipe
+import io.vertx.core.streams.ReadStream
 import io.vertx.ext.web.RoutingContext
 import io.vertx.ext.web.Session
 import org.junit.jupiter.api.BeforeEach
@@ -52,7 +52,6 @@ import kotlin.test.assertEquals
  * Run tests on the [MeasurementHandler] directly without a Vert.x environment.
  *
  * @author Klemens Muthmann
- * @version 1.0.0
  */
 @ExtendWith(MockitoExtension::class)
 class MeasurementHandlerTest {
@@ -62,9 +61,6 @@ class MeasurementHandlerTest {
 
     @Mock
     lateinit var mockResponse: HttpServerResponse
-
-    @Mock
-    lateinit var mockPipe: Pipe<Buffer>
 
     @Mock
     lateinit var mockUser: User
@@ -95,7 +91,6 @@ class MeasurementHandlerTest {
             on { getHeader(any()) } doAnswer { getHeaderCall ->
                 headers.get(getHeaderCall.getArgument(0, String::class.java))
             }
-            on { pipe() } doReturn mockPipe
         }
 
         mockSession = mock {
@@ -134,7 +129,7 @@ class MeasurementHandlerTest {
         val mockBytesUploadedCall = mock<Future<Long>> {}
         whenever(mockStorageService.bytesUploaded(any())).thenReturn(mockBytesUploadedCall)
         val mockStoreCall = mock<Future<Status>> {}
-        whenever(mockStorageService.store(any<Pipe<Buffer>>(), any<UploadMetaData>())).thenReturn(mockStoreCall)
+        whenever(mockStorageService.store(any<ReadStream<Buffer>>(), any<UploadMetaData>())).thenReturn(mockStoreCall)
 
         // Act
         oocut.handle(mockRoutingContext)
@@ -177,7 +172,7 @@ class MeasurementHandlerTest {
 
         // Assert
         argumentCaptor<UploadMetaData> {
-            verify(mockStorageService).store(eq(mockPipe), capture())
+            verify(mockStorageService).store(eq(mockRequest), capture())
 
             assertEquals(mockUser, firstValue.user)
             assertEquals(ContentRange(0L, 9L, 10L), firstValue.contentRange)

--- a/src/test/kotlin/de/cyface/collector/storage/cloud/GoogleCloudStorageTest.kt
+++ b/src/test/kotlin/de/cyface/collector/storage/cloud/GoogleCloudStorageTest.kt
@@ -22,146 +22,22 @@ import com.google.api.gax.paging.Page
 import com.google.cloud.storage.Bucket
 import com.google.cloud.storage.Storage
 import com.google.cloud.storage.Storage.BucketListOption
-import de.cyface.collector.model.ContentRange
-import de.cyface.collector.model.RequestMetaData
-import de.cyface.collector.model.User
-import de.cyface.collector.storage.StatusType
-import de.cyface.collector.storage.UploadMetaData
-import de.cyface.collector.storage.exception.ContentRangeNotMatchingFileSize
-import io.vertx.core.Future
-import io.vertx.core.Handler
-import io.vertx.core.Vertx
-import io.vertx.core.buffer.Buffer
-import io.vertx.core.streams.Pipe
-import io.vertx.core.streams.WriteStream
-import io.vertx.ext.reactivestreams.ReactiveWriteStream
 import org.mockito.kotlin.any
-import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
-import org.reactivestreams.FlowAdapters
 import java.time.OffsetDateTime
 import java.time.temporal.ChronoUnit
 import java.util.UUID
-import java.util.concurrent.Callable
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Flow
-import java.util.concurrent.SubmissionPublisher
-import java.util.concurrent.TimeUnit
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 /**
  * Tests for the code writing data to and reading data from Google Cloud Storage.
  * These tests do not actually create a connection but rather make sure, the correct API methods get called.
  *
  * @author Klemens Muthmann
- * @version 1.1.0
  */
 class GoogleCloudStorageTest {
-
-    /**
-     * This test simulates what a Vert.x `Pipe` does with a regular `SubmissionPublisher`.
-     * It sends two data packages via the publisher and checks that both packages are processed
-     * properly by the `CloudStorageSubscriber`.
-     */
-    @Test
-    fun `Happy Path Test for Getting data from a ReactiveStreams Publisher into a CloudStorageSubscriber`() {
-        // Arrange
-        val cloudStorage: CloudStorage = mock()
-        val mockedVertx = mock<Vertx>()
-        val oocut = CloudStorageSubscriber<Buffer>(cloudStorage, 23L, mockedVertx)
-        val publisher = SubmissionPublisher<Buffer>()
-        val firstDataPackage = "Hello World!"
-        val secondDataPackage = "Hello Mars!"
-        val lock = CountDownLatch(1)
-
-        // Act
-        publisher.subscribe(FlowAdapters.toFlowSubscriber(oocut))
-        publisher.subscribe(object : Flow.Subscriber<Buffer> {
-            override fun onSubscribe(subscription: Flow.Subscription?) {
-                // Nothing to do here.
-            }
-
-            override fun onError(throwable: Throwable?) {
-                // Nothing to do here.
-            }
-
-            override fun onComplete() {
-                lock.countDown()
-            }
-
-            override fun onNext(item: Buffer) {
-                // Nothing to do here.
-            }
-        })
-        publisher.submit(Buffer.buffer(firstDataPackage))
-        publisher.submit(Buffer.buffer(secondDataPackage))
-
-        lock.await(5L, TimeUnit.SECONDS)
-        // Assert
-        argumentCaptor<Callable<Unit>> {
-            verify(mockedVertx, times(2)).executeBlocking(capture())
-
-            allValues[0].call()
-            allValues[1].call()
-        }
-        verify(cloudStorage).write(firstDataPackage.toByteArray(Charsets.UTF_8))
-        verify(cloudStorage).write(firstDataPackage.toByteArray(Charsets.UTF_8))
-    }
-
-    /**
-     * This test checks that storing data results in registering the correct stream to the provided `Pipe`.
-     * The test for actually writing the data is included
-     * [here][de.cyface.collector.storage.cloud.GoogleCloudStorageTest.Happy Path Test for Getting data from a
-     * ReactiveStreams Publisher into a CloudStorageSubscriber]
-     */
-    @Test
-    fun `Happy Path Test for Storing some Data`() {
-        // Arrange
-        val mockDatabase: MongoDatabase = mock()
-        val cloudStorage: CloudStorage = mock {
-            on { bytesUploaded() } doReturn 10L
-        }
-        val mockCloudStorageFactory = CloudStorageFactory { cloudStorage }
-        val oocut = GoogleCloudStorageService(
-            mockDatabase,
-            Vertx.vertx(),
-            mockCloudStorageFactory
-        )
-        val resultFutureMock: Future<Void> = mock()
-        val toFuture: Future<Void> = mock {
-            on { onSuccess(any()) } doReturn resultFutureMock
-        }
-        val pipe: Pipe<Buffer> = mock {
-            on { to(any()) } doReturn toFuture
-        }
-        val user: User = mock()
-        val contentRange = ContentRange(0L, 9L, 10L)
-        val uploadIdentifier = UUID.randomUUID()
-        val metaData: RequestMetaData = metadata()
-        val uploadMetaData = UploadMetaData(user, contentRange, uploadIdentifier, metaData)
-
-        // Act
-        val ret = oocut.store(pipe, uploadMetaData)
-
-        // Assert
-        verify(pipe).to(any<ReactiveWriteStream<Buffer>>())
-        argumentCaptor<Handler<Void>> {
-            verify(toFuture).onSuccess(capture())
-
-            firstValue.handle(null)
-        }
-
-        assertTrue(ret.isComplete)
-        assertTrue(ret.succeeded())
-        assertEquals(10L, ret.result().byteSize)
-        assertEquals(StatusType.COMPLETE, ret.result().type)
-        assertEquals(uploadIdentifier, ret.result().uploadIdentifier)
-    }
 
     /**
      * Check that [GoogleCloudCleanupOperation] cleans only old files.
@@ -219,69 +95,5 @@ class GoogleCloudStorageTest {
         // Assert
         verify(mockStorage).delete(testTemporaryFile)
         verify(mockStorage).delete(testDataFile)
-    }
-
-    /**
-     * Tests that uploading a file with a wrong size actually produces the correct error message.
-     */
-    @Test
-    fun `A Mismatch between file size and content range should fail`() {
-        // Arrange
-        val database: Database = mock()
-        val vertx: Vertx = mock()
-        val mockCloudStorage: CloudStorage = mock {
-            on { bytesUploaded() } doReturn 4
-        }
-        val cloudStorageFactory: CloudStorageFactory = mock {
-            on { create(any<UUID>()) } doReturn mockCloudStorage
-        }
-        val oocut = GoogleCloudStorageService(database, vertx, cloudStorageFactory)
-        val mockToFuture: Future<Void> = mock()
-        val mockPipe: Pipe<Buffer> = mock {
-            on { to(any<WriteStream<Buffer>>()) } doReturn mockToFuture
-        }
-        val metadata: UploadMetaData = mock {
-            on { contentRange } doReturn ContentRange(5, 7, 3)
-            on { uploadIdentifier } doReturn UUID.randomUUID()
-        }
-
-        // Act
-        val result = oocut.store(mockPipe, metadata)
-
-        // Assert
-        argumentCaptor<Handler<Void>> {
-            verify(mockToFuture).onSuccess(capture())
-
-            firstValue.handle(null)
-        }
-        assertTrue(result.isComplete)
-        assertTrue(result.failed())
-        assertEquals(
-            ContentRangeNotMatchingFileSize(
-                """
-                Response: 500, Content-Range (ContentRange(fromIndex=5, toIndex=7, totalBytes=3)) not matching file size (4)
-                """.trim()
-            ),
-            result.cause(),
-        )
-    }
-
-    /**
-     * Provide some example metadata usable by tests.
-     */
-    private fun metadata(): RequestMetaData {
-        return RequestMetaData(
-            deviceIdentifier = "78370516-4f7e-11ed-bdc3-0242ac120002",
-            measurementIdentifier = "1",
-            operatingSystemVersion = "iOS",
-            deviceType = "iPhone16",
-            applicationVersion = "3.2.1",
-            length = 20.0,
-            locationCount = 434,
-            startLocation = RequestMetaData.GeoLocation(512367323L, 51.0, 13.0),
-            endLocation = RequestMetaData.GeoLocation(512377323L, 51.5, 13.2),
-            modality = "BICYCLE",
-            formatVersion = 3
-        )
     }
 }

--- a/src/test/kotlin/de/cyface/collector/storage/cloud/GoogleCloudStorageVertxTest.kt
+++ b/src/test/kotlin/de/cyface/collector/storage/cloud/GoogleCloudStorageVertxTest.kt
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2024 Cyface GmbH
+ *
+ * This file is part of the Cyface Data Collector.
+ *
+ * The Cyface Data Collector is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Cyface Data Collector is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Cyface Data Collector. If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.cyface.collector.storage.cloud
+
+import de.cyface.collector.model.ContentRange
+import de.cyface.collector.model.RequestMetaData
+import de.cyface.collector.model.User
+import de.cyface.collector.storage.StatusType
+import de.cyface.collector.storage.UploadMetaData
+import de.cyface.collector.storage.exception.ContentRangeNotMatchingFileSize
+import io.vertx.core.Vertx
+import io.vertx.core.buffer.Buffer
+import io.vertx.core.file.OpenOptions
+import io.vertx.junit5.VertxExtension
+import io.vertx.junit5.VertxTestContext
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.reactivestreams.FlowAdapters
+import java.util.UUID
+import java.util.concurrent.SubmissionPublisher
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * This tests the interaction with the classes for Google Cloud storage, while mocking away actual communication with
+ * Google.
+ *
+ * @author Klemens Muthmann
+ */
+@ExtendWith(VertxExtension::class)
+class GoogleCloudStorageVertxTest {
+    /**
+     * This test checks that storing data results in registering the correct stream to the provided `Pipe`.
+     * The test for actually writing the data is included
+     * [here][de.cyface.collector.storage.cloud.GoogleCloudStorageTest.Happy Path Test for Getting data from a
+     * ReactiveStreams Publisher into a CloudStorageSubscriber]
+     */
+    @Test
+    fun `Happy Path Test for Storing some Data`(vertx: Vertx, vertxTestContext: VertxTestContext) {
+        // Arrange
+        val mockDatabase: MongoDatabase = mock()
+        val cloudStorage: CloudStorage = mock {
+            on { bytesUploaded() } doReturn 10L
+        }
+        val mockCloudStorageFactory = CloudStorageFactory { cloudStorage }
+        val oocut = GoogleCloudStorageService(
+            mockDatabase,
+            vertx,
+            mockCloudStorageFactory
+        )
+        val exampleImage = this.javaClass.getResource("/example-image.jpg").file
+        val readStream = vertx.fileSystem().openBlocking(exampleImage, OpenOptions())
+        val user: User = mock()
+        val contentRange = ContentRange(0L, 9L, 10L)
+        val uploadIdentifier = UUID.randomUUID()
+        val metaData: RequestMetaData = metadata()
+        val uploadMetaData = UploadMetaData(user, contentRange, uploadIdentifier, metaData)
+
+        // Act
+        val ret = oocut.store(readStream, uploadMetaData)
+
+        // Assert
+        ret.onComplete(
+            vertxTestContext.succeeding {
+                vertxTestContext.verify {
+                    assertEquals(10L, ret.result().byteSize)
+                    assertEquals(StatusType.COMPLETE, ret.result().type)
+                    assertEquals(uploadIdentifier, ret.result().uploadIdentifier)
+                }
+
+                vertxTestContext.completeNow()
+            }
+        )
+    }
+
+    /**
+     * Tests that uploading a file with a wrong size actually produces the correct error message.
+     */
+    @Test
+    fun `A Mismatch between file size and content range should fail`(vertx: Vertx, vertxTestContext: VertxTestContext) {
+        // Arrange
+        val database: Database = mock()
+        val mockCloudStorage: CloudStorage = mock {
+            on { bytesUploaded() } doReturn 4
+        }
+        val cloudStorageFactory: CloudStorageFactory = mock {
+            on { create(any<UUID>()) } doReturn mockCloudStorage
+        }
+        val oocut = GoogleCloudStorageService(database, vertx, cloudStorageFactory)
+        val metadata: UploadMetaData = mock {
+            on { contentRange } doReturn ContentRange(5, 7, 3)
+            on { uploadIdentifier } doReturn UUID.randomUUID()
+        }
+        val exampleImage = this.javaClass.getResource("/example-image.jpg").file
+        val readStream = vertx.fileSystem().openBlocking(exampleImage, OpenOptions())
+
+        // Act
+        val result = oocut.store(readStream, metadata)
+
+        // Assert
+        result.onComplete(
+            vertxTestContext.failing {
+                vertxTestContext.verify {
+                    assertTrue(result.failed())
+                    assertEquals(
+                        ContentRangeNotMatchingFileSize(
+                            """
+                Response: 500, Content-Range (ContentRange(fromIndex=5, toIndex=7, totalBytes=3)) not matching file size (4)
+                """.trim()
+                        ),
+                        result.cause(),
+                    )
+                }
+
+                vertxTestContext.completeNow()
+            }
+        )
+    }
+
+    /**
+     * This test simulates what a Vert.x `Pipe` does with a regular `SubmissionPublisher`.
+     * It sends two data packages via the publisher and checks that both packages are processed
+     * properly by the `CloudStorageSubscriber`.
+     */
+    @Suppress("MaxLineLength")
+    @Test
+    fun `Happy Path Test for Getting data from a ReactiveStreams Publisher into a CloudStorageSubscriber`(
+        vertx: Vertx,
+        vertxTestContext: VertxTestContext
+    ) {
+        // Arrange
+        val cloudStorage: CloudStorage = mock()
+        val oocut = CloudStorageSubscriber<Buffer>(cloudStorage, 23L, vertx)
+        val publisher = SubmissionPublisher<Buffer>()
+        val firstDataPackage = "Hello World!"
+        val secondDataPackage = "Hello Mars!"
+        oocut.dataWrittenListener = object : CloudStorageSubscriber.DataWrittenListener {
+            override fun dataWritten() {
+                // Assert
+                vertxTestContext.verify {
+                    verify(cloudStorage).write(firstDataPackage.toByteArray(Charsets.UTF_8))
+                    verify(cloudStorage).write(firstDataPackage.toByteArray(Charsets.UTF_8))
+                }
+                vertxTestContext.completeNow()
+            }
+        }
+
+        // Act
+        publisher.subscribe(FlowAdapters.toFlowSubscriber(oocut))
+
+        publisher.submit(Buffer.buffer(firstDataPackage))
+        publisher.submit(Buffer.buffer(secondDataPackage))
+    }
+
+    /**
+     * Provide some example metadata usable by tests.
+     */
+    private fun metadata(): RequestMetaData {
+        return RequestMetaData(
+            deviceIdentifier = "78370516-4f7e-11ed-bdc3-0242ac120002",
+            measurementIdentifier = "1",
+            operatingSystemVersion = "iOS",
+            deviceType = "iPhone16",
+            applicationVersion = "3.2.1",
+            length = 20.0,
+            locationCount = 434,
+            startLocation = RequestMetaData.GeoLocation(512367323L, 51.0, 13.0),
+            endLocation = RequestMetaData.GeoLocation(512377323L, 51.5, 13.2),
+            modality = "BICYCLE",
+            formatVersion = 3
+        )
+    }
+}

--- a/src/test/kotlin/de/cyface/collector/storage/gridfs/GridFSStorageIT.kt
+++ b/src/test/kotlin/de/cyface/collector/storage/gridfs/GridFSStorageIT.kt
@@ -50,7 +50,6 @@ import kotlin.test.assertNotNull
  * An integration test to check whether storing data to an embedded GridFS works as expected.
  *
  * @author Klemens Muthmann
- * @version 1.0.2
  */
 @ExtendWith(VertxExtension::class)
 class GridFSStorageIT {
@@ -99,7 +98,6 @@ class GridFSStorageIT {
             testFileURI.absolutePathString(),
             OpenOptions(),
             context.succeeding {
-                val pipe = it.pipe()
                 val user = User(UUID.randomUUID(), "test-user")
                 val uploadIdentifier = UUID.randomUUID()
                 val contentRange = ContentRange(0L, 3L, 4L)
@@ -110,7 +108,7 @@ class GridFSStorageIT {
                     metaData
                 )
                 oocut.store(
-                    pipe,
+                    it,
                     uploadMetaData
                 ).onComplete(
                     context.succeeding {


### PR DESCRIPTION
Upload used to be not complete, due to ReadStream closing as soon as everything was read. However it is necessary to wait for the WriteStream to also having finished. Thus I introduced a listener to the write stream and configured the input pipe to only close after the WriteStream has processed everything.