### PR TITLE
[CY-6728] Bind API port to localhost by default, add LAN exposure option

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,21 @@ The Collector API is by default available via port 8080.
 This means if you boot up everything using the default settings, the Collector API is accessible via `http://localhost:8080/api/v4/`.
 
 **ATTENTION: The docker setup should only be used for development purposes.**
-It exposes the Cyface data collector as well as the ports of the Mongo database instance freely on the local network.
+
+By default the API port is bound to `127.0.0.1` (localhost only).
+To reach the collector from a physical phone on the same Wi-Fi network, copy the
+environment template and enable LAN exposure:
+
+```bash
+cp src/main/docker/.env.template src/main/docker/.env
+# Then uncomment API_BIND_ADDRESS=0.0.0.0 in .env
+```
+
+The `.env` file also lets you select JWT or OAuth via `COMPOSE_FILE` so you can
+run plain `docker compose up` without `-f` flags. See `.env.template` for details.
+
+**Do not set `API_BIND_ADDRESS=0.0.0.0` on shared or public Wi-Fi** -- it opens
+the port to everyone on the network.
 
 Use `docker-compose ps` to see which ports are mapped to which by Docker.
 For using such a setup in production, you may create your own Docker setup, based on our development one.

--- a/src/main/docker/.env.template
+++ b/src/main/docker/.env.template
@@ -1,0 +1,19 @@
+# Copy this file to .env and adjust as needed.
+# Docker Compose reads .env automatically -- no extra flags required.
+
+# --- Authentication variant ---
+# Uncomment ONE of the following lines to allow plain `docker compose up`
+# without -f flags. Leave both commented to keep using -f explicitly.
+#COMPOSE_FILE=compose-jwt.yaml
+#COMPOSE_FILE=compose-oauth.yaml
+
+# --- JWK for JWT authentication ---
+# Required when using compose-jwt.yaml.
+#CYFACE_JWK="{\"kty\":\"RSA\",\"alg\":\"RS256\",\"use\":\"sig\",\"kid\":\"1\",\"n\":\"...\",\"e\":\"AQAB\"}"
+
+# --- LAN exposure ---
+# By default the API binds to 127.0.0.1 (localhost only).
+# Set to 0.0.0.0 to expose the API on your LAN, e.g. for testing from a
+# physical phone on the same Wi-Fi network.
+# WARNING: Do NOT use this on shared or public Wi-Fi.
+#API_BIND_ADDRESS=0.0.0.0

--- a/src/main/docker/compose-jwt.yaml
+++ b/src/main/docker/compose-jwt.yaml
@@ -61,7 +61,7 @@ services:
     build: container-jwt
     image: data-collector:0.0.0
     ports:
-      - "127.0.0.1:8080:8080"
+      - "${API_BIND_ADDRESS:-127.0.0.1}:8080:8080"
     networks:
       - database
       - default

--- a/src/main/docker/compose-jwt.yaml
+++ b/src/main/docker/compose-jwt.yaml
@@ -61,6 +61,8 @@ services:
     build: container-jwt
     image: data-collector:0.0.0
     ports:
+      # Binds to localhost by default. Set API_BIND_ADDRESS=0.0.0.0 in .env
+      # to expose to LAN (see .env.template).
       - "${API_BIND_ADDRESS:-127.0.0.1}:8080:8080"
     networks:
       - database

--- a/src/main/docker/compose-oauth.yaml
+++ b/src/main/docker/compose-oauth.yaml
@@ -61,7 +61,7 @@ services:
     build: container-oauth
     image: data-collector:0.0.0
     ports:
-      - "127.0.0.1:8080:8080"
+      - "${API_BIND_ADDRESS:-127.0.0.1}:8080:8080"
     networks:
       - database
       - authentication

--- a/src/main/docker/compose-oauth.yaml
+++ b/src/main/docker/compose-oauth.yaml
@@ -61,6 +61,8 @@ services:
     build: container-oauth
     image: data-collector:0.0.0
     ports:
+      # Binds to localhost by default. Set API_BIND_ADDRESS=0.0.0.0 in .env
+      # to expose to LAN (see .env.template).
       - "${API_BIND_ADDRESS:-127.0.0.1}:8080:8080"
     networks:
       - database


### PR DESCRIPTION
Use API_BIND_ADDRESS env var (defaults to 127.0.0.1) in compose files instead of a hardcoded address. Add .env.template showing how to select JWT/OAuth and optionally open the port to LAN for physical device testing.