### PR TITLE
[BIK-1765] Fix introspect client ID and JWT claim reading

### DIFF
--- a/src/main/docker/compose-oauth.yaml
+++ b/src/main/docker/compose-oauth.yaml
@@ -98,13 +98,31 @@ services:
     networks:
       - authentication
     environment:
-      - KEYCLOAK_ADMIN=admin 
+      - KEYCLOAK_ADMIN=admin
       - KEYCLOAK_ADMIN_PASSWORD=admin
     command: start-dev --import-realm
     volumes:
       - ./keycloak/providers:/opt/keycloak/providers
       - ./keycloak/data:/opt/keycloak/data
       - ./keycloak/themes:/opt/keycloak/themes
+    depends_on:
+      - mailpit
+
+  # Fake SMTP server that captures every outgoing email and exposes a web UI.
+  # Inspect mails at http://localhost:8025 (subject, from, to, body, HTML).
+  # Keycloak is configured to deliver mail to mailpit:1025 via the realm's
+  # smtpServer block (see keycloak/data/import/rfr-realm.json).
+  mailpit:
+    container_name: collector_mailpit
+    image: axllent/mailpit:latest
+    ports:
+      - "127.0.0.1:8025:8025"  # Web UI
+      - "127.0.0.1:1025:1025"  # SMTP (also reachable from host for debugging)
+    networks:
+      - authentication
+    environment:
+      MP_SMTP_AUTH_ACCEPT_ANY: "true"
+      MP_SMTP_AUTH_ALLOW_INSECURE: "true"
 
 volumes:
   collector_mongo-db:

--- a/src/main/docker/compose-oauth.yaml
+++ b/src/main/docker/compose-oauth.yaml
@@ -87,12 +87,35 @@ services:
       test: [ "CMD", "curl", "-f", "http://localhost:8080/" ]
 
 
-  # Keycloak Authentication Server
+  # Keycloak Authentication Server.
+  #
+  # The realm export hardcodes `frontendUrl=http://authentication:8080`
+  # (see rfr-realm_VERSION_see-keycloak-image-repo.json). This is the
+  # original RFR-774 fix and supports the in-Docker API + "thin" external
+  # client (postman, Android, iOS, curl) flow:
+  #   - The collector API container reaches Keycloak at authentication:8080.
+  #   - External thin clients hit Keycloak via the host port mapping at
+  #     localhost:8081 and get a token whose `iss` is
+  #     `http://authentication:8080` regardless of the URL used.
+  #   - The API validates `iss` against authentication:8080 -> match.
+  #   - Thin clients never do OIDC discovery and never validate the token
+  #     themselves, so the unreachable-from-host authentication URL inside
+  #     the discovery doc does not matter for them.
+  #
+  # This setup will NOT work with a SPA / web-app client because SPAs DO
+  # fetch the OIDC discovery doc and validate JWKS -- with hardcoded
+  # frontendUrl those URLs point at unreachable-from-host
+  # authentication:8080. For SPA-friendly local dev, run the standalone
+  # Keycloak from cyface/keycloak-image (./start-dev.sh) which uses
+  # frontendUrl="" on the radsim realm.
+  #
+  # The realm JSON is a verbatim copy of the canonical version maintained
+  # in the cyface/keycloak-image repo (data/import/rfr-realm_VERSION.json)
+  # -- edit there first, re-sync here. The full RFR-774 explanation lives
+  # in cyface/keycloak-image/docker-compose.dev.yml.
   authentication:
     container_name: collector_authentication
     image: quay.io/keycloak/keycloak:22.0.1
-    # For the issuer of the auth token to be correct, Frontend-URL needs to be set to authentication:8080 [RFR-774]
-    # This is pre-configured in `/keycloak/data/import/rfr-realm.json`: `"frontendUrl": "http://authentication:8080",`
     ports:
       - "127.0.0.1:8081:8080"
     networks:
@@ -111,7 +134,7 @@ services:
   # Fake SMTP server that captures every outgoing email and exposes a web UI.
   # Inspect mails at http://localhost:8025 (subject, from, to, body, HTML).
   # Keycloak is configured to deliver mail to mailpit:1025 via the realm's
-  # smtpServer block (see keycloak/data/import/rfr-realm.json).
+  # smtpServer block (see keycloak/data/import/rfr-realm_VERSION_see-keycloak-image-repo.json).
   mailpit:
     container_name: collector_mailpit
     image: axllent/mailpit:latest

--- a/src/main/docker/keycloak/data/import/rfr-realm.json
+++ b/src/main/docker/keycloak/data/import/rfr-realm.json
@@ -1678,6 +1678,18 @@
     "xXSSProtection" : "1; mode=block",
     "strictTransportSecurity" : "max-age=31536000; includeSubDomains"
   },
+  "smtpServer" : {
+    "host" : "mailpit",
+    "port" : "1025",
+    "from" : "noreply@cyface.local",
+    "fromDisplayName" : "Cyface (local dev)",
+    "replyTo" : "noreply@cyface.local",
+    "replyToDisplayName" : "Cyface (local dev)",
+    "envelopeFrom" : "",
+    "starttls" : "false",
+    "ssl" : "false",
+    "auth" : "false"
+  },
   "loginTheme" : "rfr",
   "accountTheme" : "",
   "adminTheme" : "",

--- a/src/main/docker/keycloak/data/import/rfr-realm.json
+++ b/src/main/docker/keycloak/data/import/rfr-realm.json
@@ -263,6 +263,7 @@
         "attributes" : { }
       } ],
       "security-admin-console" : [ ],
+      "adhocracy-provider" : [ ],
       "account-console" : [ ],
       "android-app" : [ {
         "id" : "a16c0cfe-80f2-4903-83d7-55531571362d",
@@ -530,7 +531,95 @@
     } ],
     "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
     "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
-
+  }, {
+    "id" : "c8253880-aebd-4bb7-8927-8c00b4cd916b",
+    "clientId" : "adhocracy-provider",
+    "name" : "Cyface Oauth",
+    "description" : "",
+    "rootUrl" : "https://ready-for-robots.de",
+    "adminUrl" : "",
+    "baseUrl" : "",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/accounts/keycloak/login/callback/" ],
+    "webOrigins" : [ "/accounts/keycloak/login/" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : true,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "client.secret.creation.time" : "1683556408",
+      "post.logout.redirect.uris" : "+",
+      "oauth2.device.authorization.grant.enabled" : "false",
+      "use.jwks.url" : "false",
+      "backchannel.logout.revoke.offline.tokens" : "false",
+      "use.refresh.tokens" : "true",
+      "exclude.session.state.from.auth.response" : "false",
+      "tls-client-certificate-bound-access-tokens" : "false",
+      "oidc.ciba.grant.enabled" : "false",
+      "backchannel.logout.session.required" : "true",
+      "client_credentials.use_refresh_token" : "false",
+      "acr.loa.map" : "{}",
+      "require.pushed.authorization.requests" : "false",
+      "display.on.consent.screen" : "false",
+      "token.response.type.bearer.lower-case" : "false"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "fff4637d-7f96-4347-82f1-0fcc229b7960",
+      "name" : "Client Host",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.session.note" : "clientHost",
+        "userinfo.token.claim" : "true",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "clientHost",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "d1d42d08-41bf-4d8c-9435-21a704b5bb4e",
+      "name" : "Client IP Address",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.session.note" : "clientAddress",
+        "userinfo.token.claim" : "true",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "clientAddress",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "edb11d9c-9d25-4df8-939d-22eb7967262c",
+      "name" : "Client ID",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.session.note" : "clientId",
+        "userinfo.token.claim" : "true",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "clientId",
+        "jsonType.label" : "String"
+      }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
   }, {
     "id" : "47aad148-751e-4e8a-8b13-dfe50ffcc20a",
     "clientId" : "admin-cli",
@@ -636,36 +725,6 @@
         "access.token.claim" : "true",
         "claim.name" : "clientHost",
         "jsonType.label" : "String"
-      }
-    }, {
-      "name" : "provider-audience",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-audience-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "included.client.audience" : "provider",
-        "id.token.claim" : "false",
-        "access.token.claim" : "true"
-      }
-    }, {
-      "name" : "collector-audience",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-audience-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "included.client.audience" : "collector",
-        "id.token.claim" : "false",
-        "access.token.claim" : "true"
-      }
-    }, {
-      "name" : "incentives-audience",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-audience-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "included.client.audience" : "incentives",
-        "id.token.claim" : "false",
-        "access.token.claim" : "true"
       }
     } ],
     "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
@@ -897,36 +956,6 @@
         "claim.name" : "clientHost",
         "jsonType.label" : "String"
       }
-    }, {
-      "name" : "provider-audience",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-audience-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "included.client.audience" : "provider",
-        "id.token.claim" : "false",
-        "access.token.claim" : "true"
-      }
-    }, {
-      "name" : "collector-audience",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-audience-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "included.client.audience" : "collector",
-        "id.token.claim" : "false",
-        "access.token.claim" : "true"
-      }
-    }, {
-      "name" : "incentives-audience",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-audience-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "included.client.audience" : "incentives",
-        "id.token.claim" : "false",
-        "access.token.claim" : "true"
-      }
     } ],
     "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
     "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
@@ -1127,17 +1156,6 @@
     "authenticationFlowBindingOverrides" : { },
     "fullScopeAllowed" : true,
     "nodeReRegistrationTimeout" : -1,
-    "protocolMappers" : [ {
-      "name" : "provider-audience",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-audience-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "included.client.audience" : "provider",
-        "id.token.claim" : "false",
-        "access.token.claim" : "true"
-      }
-    } ],
     "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
     "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
   }, {
@@ -1378,7 +1396,7 @@
         "userinfo.token.claim" : "true",
         "user.attribute" : "municipality",
         "id.token.claim" : "false",
-        "access.token.claim" : "true",
+        "access.token.claim" : "false",
         "claim.name" : "municipality"
       }
     }, {

--- a/src/main/docker/keycloak/data/import/rfr-realm.json
+++ b/src/main/docker/keycloak/data/import/rfr-realm.json
@@ -263,7 +263,6 @@
         "attributes" : { }
       } ],
       "security-admin-console" : [ ],
-      "adhocracy-provider" : [ ],
       "account-console" : [ ],
       "android-app" : [ {
         "id" : "a16c0cfe-80f2-4903-83d7-55531571362d",
@@ -531,95 +530,7 @@
     } ],
     "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
     "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
-  }, {
-    "id" : "c8253880-aebd-4bb7-8927-8c00b4cd916b",
-    "clientId" : "adhocracy-provider",
-    "name" : "Cyface Oauth",
-    "description" : "",
-    "rootUrl" : "https://ready-for-robots.de",
-    "adminUrl" : "",
-    "baseUrl" : "",
-    "surrogateAuthRequired" : false,
-    "enabled" : true,
-    "alwaysDisplayInConsole" : false,
-    "clientAuthenticatorType" : "client-secret",
-    "redirectUris" : [ "/accounts/keycloak/login/callback/" ],
-    "webOrigins" : [ "/accounts/keycloak/login/" ],
-    "notBefore" : 0,
-    "bearerOnly" : false,
-    "consentRequired" : false,
-    "standardFlowEnabled" : true,
-    "implicitFlowEnabled" : false,
-    "directAccessGrantsEnabled" : true,
-    "serviceAccountsEnabled" : false,
-    "publicClient" : true,
-    "frontchannelLogout" : true,
-    "protocol" : "openid-connect",
-    "attributes" : {
-      "client.secret.creation.time" : "1683556408",
-      "post.logout.redirect.uris" : "+",
-      "oauth2.device.authorization.grant.enabled" : "false",
-      "use.jwks.url" : "false",
-      "backchannel.logout.revoke.offline.tokens" : "false",
-      "use.refresh.tokens" : "true",
-      "exclude.session.state.from.auth.response" : "false",
-      "tls-client-certificate-bound-access-tokens" : "false",
-      "oidc.ciba.grant.enabled" : "false",
-      "backchannel.logout.session.required" : "true",
-      "client_credentials.use_refresh_token" : "false",
-      "acr.loa.map" : "{}",
-      "require.pushed.authorization.requests" : "false",
-      "display.on.consent.screen" : "false",
-      "token.response.type.bearer.lower-case" : "false"
-    },
-    "authenticationFlowBindingOverrides" : { },
-    "fullScopeAllowed" : true,
-    "nodeReRegistrationTimeout" : -1,
-    "protocolMappers" : [ {
-      "id" : "fff4637d-7f96-4347-82f1-0fcc229b7960",
-      "name" : "Client Host",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "user.session.note" : "clientHost",
-        "userinfo.token.claim" : "true",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "clientHost",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "d1d42d08-41bf-4d8c-9435-21a704b5bb4e",
-      "name" : "Client IP Address",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "user.session.note" : "clientAddress",
-        "userinfo.token.claim" : "true",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "clientAddress",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "edb11d9c-9d25-4df8-939d-22eb7967262c",
-      "name" : "Client ID",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "user.session.note" : "clientId",
-        "userinfo.token.claim" : "true",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "clientId",
-        "jsonType.label" : "String"
-      }
-    } ],
-    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
-    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+
   }, {
     "id" : "47aad148-751e-4e8a-8b13-dfe50ffcc20a",
     "clientId" : "admin-cli",
@@ -725,6 +636,36 @@
         "access.token.claim" : "true",
         "claim.name" : "clientHost",
         "jsonType.label" : "String"
+      }
+    }, {
+      "name" : "provider-audience",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "included.client.audience" : "provider",
+        "id.token.claim" : "false",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "name" : "collector-audience",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "included.client.audience" : "collector",
+        "id.token.claim" : "false",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "name" : "incentives-audience",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "included.client.audience" : "incentives",
+        "id.token.claim" : "false",
+        "access.token.claim" : "true"
       }
     } ],
     "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
@@ -956,6 +897,36 @@
         "claim.name" : "clientHost",
         "jsonType.label" : "String"
       }
+    }, {
+      "name" : "provider-audience",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "included.client.audience" : "provider",
+        "id.token.claim" : "false",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "name" : "collector-audience",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "included.client.audience" : "collector",
+        "id.token.claim" : "false",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "name" : "incentives-audience",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "included.client.audience" : "incentives",
+        "id.token.claim" : "false",
+        "access.token.claim" : "true"
+      }
     } ],
     "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
     "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
@@ -1156,6 +1127,17 @@
     "authenticationFlowBindingOverrides" : { },
     "fullScopeAllowed" : true,
     "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "name" : "provider-audience",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "included.client.audience" : "provider",
+        "id.token.claim" : "false",
+        "access.token.claim" : "true"
+      }
+    } ],
     "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
     "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
   }, {
@@ -1407,7 +1389,7 @@
         "userinfo.token.claim" : "true",
         "user.attribute" : "municipality",
         "id.token.claim" : "false",
-        "access.token.claim" : "false",
+        "access.token.claim" : "true",
         "claim.name" : "municipality"
       }
     }, {

--- a/src/main/docker/keycloak/data/import/rfr-realm.json
+++ b/src/main/docker/keycloak/data/import/rfr-realm.json
@@ -263,7 +263,6 @@
         "attributes" : { }
       } ],
       "security-admin-console" : [ ],
-      "adhocracy-provider" : [ ],
       "account-console" : [ ],
       "android-app" : [ {
         "id" : "a16c0cfe-80f2-4903-83d7-55531571362d",
@@ -531,95 +530,7 @@
     } ],
     "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
     "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
-  }, {
-    "id" : "c8253880-aebd-4bb7-8927-8c00b4cd916b",
-    "clientId" : "adhocracy-provider",
-    "name" : "Cyface Oauth",
-    "description" : "",
-    "rootUrl" : "https://ready-for-robots.de",
-    "adminUrl" : "",
-    "baseUrl" : "",
-    "surrogateAuthRequired" : false,
-    "enabled" : true,
-    "alwaysDisplayInConsole" : false,
-    "clientAuthenticatorType" : "client-secret",
-    "redirectUris" : [ "/accounts/keycloak/login/callback/" ],
-    "webOrigins" : [ "/accounts/keycloak/login/" ],
-    "notBefore" : 0,
-    "bearerOnly" : false,
-    "consentRequired" : false,
-    "standardFlowEnabled" : true,
-    "implicitFlowEnabled" : false,
-    "directAccessGrantsEnabled" : true,
-    "serviceAccountsEnabled" : false,
-    "publicClient" : true,
-    "frontchannelLogout" : true,
-    "protocol" : "openid-connect",
-    "attributes" : {
-      "client.secret.creation.time" : "1683556408",
-      "post.logout.redirect.uris" : "+",
-      "oauth2.device.authorization.grant.enabled" : "false",
-      "use.jwks.url" : "false",
-      "backchannel.logout.revoke.offline.tokens" : "false",
-      "use.refresh.tokens" : "true",
-      "exclude.session.state.from.auth.response" : "false",
-      "tls-client-certificate-bound-access-tokens" : "false",
-      "oidc.ciba.grant.enabled" : "false",
-      "backchannel.logout.session.required" : "true",
-      "client_credentials.use_refresh_token" : "false",
-      "acr.loa.map" : "{}",
-      "require.pushed.authorization.requests" : "false",
-      "display.on.consent.screen" : "false",
-      "token.response.type.bearer.lower-case" : "false"
-    },
-    "authenticationFlowBindingOverrides" : { },
-    "fullScopeAllowed" : true,
-    "nodeReRegistrationTimeout" : -1,
-    "protocolMappers" : [ {
-      "id" : "fff4637d-7f96-4347-82f1-0fcc229b7960",
-      "name" : "Client Host",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "user.session.note" : "clientHost",
-        "userinfo.token.claim" : "true",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "clientHost",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "d1d42d08-41bf-4d8c-9435-21a704b5bb4e",
-      "name" : "Client IP Address",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "user.session.note" : "clientAddress",
-        "userinfo.token.claim" : "true",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "clientAddress",
-        "jsonType.label" : "String"
-      }
-    }, {
-      "id" : "edb11d9c-9d25-4df8-939d-22eb7967262c",
-      "name" : "Client ID",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "user.session.note" : "clientId",
-        "userinfo.token.claim" : "true",
-        "id.token.claim" : "true",
-        "access.token.claim" : "true",
-        "claim.name" : "clientId",
-        "jsonType.label" : "String"
-      }
-    } ],
-    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
-    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+
   }, {
     "id" : "47aad148-751e-4e8a-8b13-dfe50ffcc20a",
     "clientId" : "admin-cli",
@@ -725,6 +636,36 @@
         "access.token.claim" : "true",
         "claim.name" : "clientHost",
         "jsonType.label" : "String"
+      }
+    }, {
+      "name" : "provider-audience",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "included.client.audience" : "provider",
+        "id.token.claim" : "false",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "name" : "collector-audience",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "included.client.audience" : "collector",
+        "id.token.claim" : "false",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "name" : "incentives-audience",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "included.client.audience" : "incentives",
+        "id.token.claim" : "false",
+        "access.token.claim" : "true"
       }
     } ],
     "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
@@ -956,6 +897,36 @@
         "claim.name" : "clientHost",
         "jsonType.label" : "String"
       }
+    }, {
+      "name" : "provider-audience",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "included.client.audience" : "provider",
+        "id.token.claim" : "false",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "name" : "collector-audience",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "included.client.audience" : "collector",
+        "id.token.claim" : "false",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "name" : "incentives-audience",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "included.client.audience" : "incentives",
+        "id.token.claim" : "false",
+        "access.token.claim" : "true"
+      }
     } ],
     "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
     "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
@@ -1156,6 +1127,17 @@
     "authenticationFlowBindingOverrides" : { },
     "fullScopeAllowed" : true,
     "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "name" : "provider-audience",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "included.client.audience" : "provider",
+        "id.token.claim" : "false",
+        "access.token.claim" : "true"
+      }
+    } ],
     "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
     "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
   }, {
@@ -1396,7 +1378,7 @@
         "userinfo.token.claim" : "true",
         "user.attribute" : "municipality",
         "id.token.claim" : "false",
-        "access.token.claim" : "false",
+        "access.token.claim" : "true",
         "claim.name" : "municipality"
       }
     }, {

--- a/src/main/docker/keycloak/data/import/rfr-realm.json
+++ b/src/main/docker/keycloak/data/import/rfr-realm.json
@@ -1192,6 +1192,17 @@
     "authenticationFlowBindingOverrides" : { },
     "fullScopeAllowed" : true,
     "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "name" : "provider-audience",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "included.client.audience" : "provider",
+        "id.token.claim" : "false",
+        "access.token.claim" : "true"
+      }
+    } ],
     "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
     "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
   } ],

--- a/src/main/docker/keycloak/data/import/rfr-realm_1.1.0_see-keycloak-image-repo.json
+++ b/src/main/docker/keycloak/data/import/rfr-realm_1.1.0_see-keycloak-image-repo.json
@@ -7,8 +7,8 @@
   "defaultSignatureAlgorithm" : "RS256",
   "revokeRefreshToken" : false,
   "refreshTokenMaxReuse" : 0,
-  "accessTokenLifespan" : 300,
-  "accessTokenLifespanForImplicitFlow" : 900,
+  "accessTokenLifespan" : 900,
+  "accessTokenLifespanForImplicitFlow" : 1800,
   "ssoSessionIdleTimeout" : 86313600,
   "ssoSessionMaxLifespan" : 86313600,
   "ssoSessionIdleTimeoutRememberMe" : 0,
@@ -65,6 +65,14 @@
           "account" : [ "view-profile", "manage-account" ]
         }
       },
+      "clientRole" : false,
+      "containerId" : "400a0f2d-f9ea-4c00-b3fa-2e8bdbc6f4b0",
+      "attributes" : { }
+    }, {
+      "id" : "ddf515c1-5e1a-416d-8343-770ee799a801",
+      "name" : "municipality-presenter",
+      "description" : "Each municipality may have multiple municipality-manager users. Only one of them may have the municipality-presenter role, which defines whose processed data the non-manager users of the municipality see.",
+      "composite" : false,
       "clientRole" : false,
       "containerId" : "400a0f2d-f9ea-4c00-b3fa-2e8bdbc6f4b0",
       "attributes" : { }
@@ -284,6 +292,7 @@
       "collector" : [ ],
       "web-app" : [ ],
       "incentives" : [ ],
+      "postman" : [ ],
       "demo-client" : [ ],
       "provider" : [ {
         "id" : "c0b51032-84e2-4465-b747-bc781203b4c9",
@@ -389,7 +398,7 @@
   "otpPolicyLookAheadWindow" : 1,
   "otpPolicyPeriod" : 30,
   "otpPolicyCodeReusable" : false,
-  "otpSupportedApplications" : [ "totpAppFreeOTPName", "totpAppMicrosoftAuthenticatorName", "totpAppGoogleName" ],
+  "otpSupportedApplications" : [ "totpAppGoogleName", "totpAppFreeOTPName", "totpAppMicrosoftAuthenticatorName" ],
   "webAuthnPolicyRpEntityName" : "keycloak",
   "webAuthnPolicySignatureAlgorithms" : [ "ES256" ],
   "webAuthnPolicyRpId" : "",
@@ -411,6 +420,33 @@
   "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister" : false,
   "webAuthnPolicyPasswordlessAcceptableAaguids" : [ ],
   "users" : [ {
+    "id" : "33f9d9d1-4fa5-4ce9-965d-0f523aaf3a44",
+    "createdTimestamp" : 1716385809973,
+    "username" : "test@cyface.de",
+    "enabled" : true,
+    "totp" : false,
+    "emailVerified" : true,
+    "firstName" : "Test",
+    "lastName" : "User",
+    "email" : "test@cyface.de",
+    "attributes" : {
+      "terms_and_conditions" : [ "1710776138" ],
+      "municipality" : [ "schkeuditz" ]
+    },
+    "credentials" : [ {
+      "id" : "72121d74-7218-4ee3-bf19-3e4a1ffc0d9f",
+      "type" : "password",
+      "userLabel" : "My password",
+      "createdDate" : 1716385830573,
+      "secretData" : "{\"value\":\"9SBIG9DXiXEtQP2d7gvljBfjU9eyfYpKdHhE6BPFUTw=\",\"salt\":\"8aW5/SP4T4fzO1mYzCHGmg==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-rfr" ],
+    "notBefore" : 0,
+    "groups" : [ ]
+  }, {
     "id" : "d7b0e1b6-a15d-4652-af9f-e06ff8d31d78",
     "createdTimestamp" : 1691670709280,
     "username" : "service-account-provider",
@@ -423,31 +459,8 @@
     "requiredActions" : [ ],
     "realmRoles" : [ "default-roles-rfr" ],
     "clientRoles" : {
-      "realm-management" : [ "query-users", "view-users" ]
+      "realm-management" : [ "view-realm", "query-users", "view-users", "manage-users" ]
     },
-    "notBefore" : 0,
-    "groups" : [ ]
-  }, {
-    "id" : "2c02f28e-00b8-421a-921f-be670b9d9330",
-    "createdTimestamp" : 1692882353775,
-    "username" : "test@cyface.de",
-    "enabled" : true,
-    "totp" : false,
-    "emailVerified" : true,
-    "firstName" : "Test",
-    "lastName" : "Tester",
-    "email" : "test@cyface.de",
-    "credentials" : [ {
-      "id" : "5eb073d5-366f-4395-b657-20d3aecbd9cb",
-      "type" : "password",
-      "userLabel" : "My password",
-      "createdDate" : 1692882374232,
-      "secretData" : "{\"value\":\"9SBIG9DXiXEtQP2d7gvljBfjU9eyfYpKdHhE6BPFUTw=\",\"salt\":\"8aW5/SP4T4fzO1mYzCHGmg==\",\"additionalParameters\":{}}",
-      "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
-    } ],
-    "disableableCredentialTypes" : [ ],
-    "requiredActions" : [ ],
-    "realmRoles" : [ "default-roles-rfr" ],
     "notBefore" : 0,
     "groups" : [ ]
   } ],
@@ -530,7 +543,6 @@
     } ],
     "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
     "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
-
   }, {
     "id" : "47aad148-751e-4e8a-8b13-dfe50ffcc20a",
     "clientId" : "admin-cli",
@@ -838,6 +850,7 @@
     "protocol" : "openid-connect",
     "attributes" : {
       "client.secret.creation.time" : "1686578386",
+      "login_theme" : "ios-app",
       "post.logout.redirect.uris" : "+",
       "oauth2.device.authorization.grant.enabled" : "false",
       "backchannel.logout.revoke.offline.tokens" : "false",
@@ -931,9 +944,45 @@
     "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
     "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
   }, {
+    "id" : "03f4eed0-6ee8-4973-83e7-b642987aae39",
+    "clientId" : "postman",
+    "name" : "Postman",
+    "description" : "Postman API Testing and Debugging Tool",
+    "rootUrl" : "",
+    "adminUrl" : "",
+    "baseUrl" : "",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/*" ],
+    "webOrigins" : [ "/*" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : true,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "oidc.ciba.grant.enabled" : "false",
+      "post.logout.redirect.uris" : "+",
+      "oauth2.device.authorization.grant.enabled" : "false",
+      "backchannel.logout.session.required" : "true",
+      "backchannel.logout.revoke.offline.tokens" : "false"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
     "id" : "537901a6-524e-44ac-b125-93deb6bdb5a5",
     "clientId" : "provider",
-    "name" : "",
+    "name" : "Provider",
     "description" : "",
     "rootUrl" : "http://localhost:8086",
     "adminUrl" : "http://localhost:8086",
@@ -1098,7 +1147,7 @@
     "enabled" : true,
     "alwaysDisplayInConsole" : false,
     "clientAuthenticatorType" : "client-secret",
-    "redirectUris" : [ "https://app.cyface.de/callback", "https://staging.cyface.de/callback" ],
+    "redirectUris" : [ "https://app.cyface.de/callback", "https://staging.cyface.de/callback", "https://app.ready-for-robots.de/callback", "https://staging.ready-for-robots.de/callback" ],
     "webOrigins" : [ "+" ],
     "notBefore" : 0,
     "bearerOnly" : false,
@@ -1141,7 +1190,7 @@
     "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
     "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
   }, {
-    "id" : "008ffc0f-634b-43f6-bef4-9e7fba868cf2",
+    "id" : "e068c8dc-df5c-4272-bf18-70b3c3597e55",
     "clientId" : "web-app_dev",
     "name" : "",
     "description" : "",
@@ -1166,9 +1215,10 @@
     "protocol" : "openid-connect",
     "attributes" : {
       "oidc.ciba.grant.enabled" : "false",
-      "post.logout.redirect.uris" : "+",
-      "oauth2.device.authorization.grant.enabled" : "false",
       "backchannel.logout.session.required" : "true",
+      "post.logout.redirect.uris" : "+",
+      "display.on.consent.screen" : "false",
+      "oauth2.device.authorization.grant.enabled" : "false",
       "backchannel.logout.revoke.offline.tokens" : "false"
     },
     "authenticationFlowBindingOverrides" : { },
@@ -1385,8 +1435,8 @@
       "consentRequired" : false,
       "config" : {
         "aggregate.attrs" : "false",
-        "multivalued" : "false",
         "userinfo.token.claim" : "true",
+        "multivalued" : "false",
         "user.attribute" : "municipality",
         "id.token.claim" : "false",
         "access.token.claim" : "true",
@@ -1674,7 +1724,7 @@
     "referrerPolicy" : "no-referrer",
     "xRobotsTag" : "none",
     "xFrameOptions" : "SAMEORIGIN",
-    "contentSecurityPolicy" : "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "contentSecurityPolicy" : "frame-ancestors 'self'; object-src 'none';",
     "xXSSProtection" : "1; mode=block",
     "strictTransportSecurity" : "max-age=31536000; includeSubDomains"
   },
@@ -1700,7 +1750,30 @@
   "enabledEventTypes" : [ "SEND_RESET_PASSWORD", "UPDATE_CONSENT_ERROR", "GRANT_CONSENT", "VERIFY_PROFILE_ERROR", "REMOVE_TOTP", "REVOKE_GRANT", "UPDATE_TOTP", "LOGIN_ERROR", "CLIENT_LOGIN", "RESET_PASSWORD_ERROR", "IMPERSONATE_ERROR", "CODE_TO_TOKEN_ERROR", "CUSTOM_REQUIRED_ACTION", "OAUTH2_DEVICE_CODE_TO_TOKEN_ERROR", "RESTART_AUTHENTICATION", "IMPERSONATE", "UPDATE_PROFILE_ERROR", "LOGIN", "OAUTH2_DEVICE_VERIFY_USER_CODE", "UPDATE_PASSWORD_ERROR", "CLIENT_INITIATED_ACCOUNT_LINKING", "TOKEN_EXCHANGE", "AUTHREQID_TO_TOKEN", "LOGOUT", "REGISTER", "DELETE_ACCOUNT_ERROR", "CLIENT_REGISTER", "IDENTITY_PROVIDER_LINK_ACCOUNT", "DELETE_ACCOUNT", "UPDATE_PASSWORD", "CLIENT_DELETE", "FEDERATED_IDENTITY_LINK_ERROR", "IDENTITY_PROVIDER_FIRST_LOGIN", "CLIENT_DELETE_ERROR", "VERIFY_EMAIL", "CLIENT_LOGIN_ERROR", "RESTART_AUTHENTICATION_ERROR", "EXECUTE_ACTIONS", "REMOVE_FEDERATED_IDENTITY_ERROR", "TOKEN_EXCHANGE_ERROR", "PERMISSION_TOKEN", "SEND_IDENTITY_PROVIDER_LINK_ERROR", "EXECUTE_ACTION_TOKEN_ERROR", "SEND_VERIFY_EMAIL", "OAUTH2_DEVICE_AUTH", "EXECUTE_ACTIONS_ERROR", "REMOVE_FEDERATED_IDENTITY", "OAUTH2_DEVICE_CODE_TO_TOKEN", "IDENTITY_PROVIDER_POST_LOGIN", "IDENTITY_PROVIDER_LINK_ACCOUNT_ERROR", "OAUTH2_DEVICE_VERIFY_USER_CODE_ERROR", "UPDATE_EMAIL", "REGISTER_ERROR", "REVOKE_GRANT_ERROR", "EXECUTE_ACTION_TOKEN", "LOGOUT_ERROR", "UPDATE_EMAIL_ERROR", "CLIENT_UPDATE_ERROR", "AUTHREQID_TO_TOKEN_ERROR", "UPDATE_PROFILE", "CLIENT_REGISTER_ERROR", "FEDERATED_IDENTITY_LINK", "SEND_IDENTITY_PROVIDER_LINK", "SEND_VERIFY_EMAIL_ERROR", "RESET_PASSWORD", "CLIENT_INITIATED_ACCOUNT_LINKING_ERROR", "OAUTH2_DEVICE_AUTH_ERROR", "UPDATE_CONSENT", "REMOVE_TOTP_ERROR", "VERIFY_EMAIL_ERROR", "SEND_RESET_PASSWORD_ERROR", "CLIENT_UPDATE", "CUSTOM_REQUIRED_ACTION_ERROR", "IDENTITY_PROVIDER_POST_LOGIN_ERROR", "UPDATE_TOTP_ERROR", "CODE_TO_TOKEN", "VERIFY_PROFILE", "GRANT_CONSENT_ERROR", "IDENTITY_PROVIDER_FIRST_LOGIN_ERROR" ],
   "adminEventsEnabled" : true,
   "adminEventsDetailsEnabled" : false,
-  "identityProviders" : [ ],
+  "identityProviders" : [ {
+    "alias" : "google",
+    "internalId" : "d68ac15d-14c0-4b5a-b9fb-c1236447d0dc",
+    "providerId" : "google",
+    "enabled" : true,
+    "updateProfileFirstLoginMode" : "on",
+    "trustEmail" : false,
+    "storeToken" : false,
+    "addReadTokenRoleOnCreate" : false,
+    "authenticateByDefault" : false,
+    "linkOnly" : false,
+    "firstBrokerLoginFlowAlias" : "first broker login",
+    "config" : {
+      "hideOnLoginPage" : "false",
+      "offlineAccess" : "false",
+      "acceptsPromptNoneForwardFromClient" : "false",
+      "clientId" : "440863438456-k6k2eab84b3t3ptpkbp210k2vpbqb3jq.apps.googleusercontent.com",
+      "disableUserInfo" : "false",
+      "filteredByClaim" : "false",
+      "syncMode" : "IMPORT",
+      "userIp" : "false",
+      "clientSecret" : "**********"
+    }
+  } ],
   "identityProviderMappers" : [ ],
   "components" : {
     "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy" : [ {
@@ -1710,7 +1783,7 @@
       "subType" : "authenticated",
       "subComponents" : { },
       "config" : {
-        "allowed-protocol-mapper-types" : [ "saml-user-property-mapper", "oidc-usermodel-property-mapper", "oidc-address-mapper", "saml-role-list-mapper", "oidc-usermodel-attribute-mapper", "saml-user-attribute-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-full-name-mapper" ]
+        "allowed-protocol-mapper-types" : [ "oidc-usermodel-attribute-mapper", "saml-user-property-mapper", "oidc-usermodel-property-mapper", "saml-role-list-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-full-name-mapper", "oidc-address-mapper", "saml-user-attribute-mapper" ]
       }
     }, {
       "id" : "929c0fd6-03d4-4e73-9fca-057d61927468",
@@ -1751,7 +1824,7 @@
       "subType" : "anonymous",
       "subComponents" : { },
       "config" : {
-        "allowed-protocol-mapper-types" : [ "oidc-usermodel-attribute-mapper", "oidc-full-name-mapper", "saml-user-property-mapper", "oidc-sha256-pairwise-sub-mapper", "saml-user-attribute-mapper", "oidc-address-mapper", "oidc-usermodel-property-mapper", "saml-role-list-mapper" ]
+        "allowed-protocol-mapper-types" : [ "oidc-usermodel-attribute-mapper", "oidc-usermodel-property-mapper", "oidc-full-name-mapper", "oidc-address-mapper", "saml-role-list-mapper", "oidc-sha256-pairwise-sub-mapper", "saml-user-attribute-mapper", "saml-user-property-mapper" ]
       }
     }, {
       "id" : "7ba11778-4a82-493c-9a22-cac0ebbf1372",
@@ -1772,6 +1845,12 @@
       "config" : {
         "allow-default-scopes" : [ "true" ]
       }
+    } ],
+    "org.keycloak.userprofile.UserProfileProvider" : [ {
+      "id" : "e0f6474b-132d-4967-b050-19a3b0335bca",
+      "providerId" : "declarative-user-profile",
+      "subComponents" : { },
+      "config" : { }
     } ],
     "org.keycloak.keys.KeyProvider" : [ {
       "id" : "5192df73-3104-42be-9ab9-e86af74e7f05",
@@ -2637,18 +2716,23 @@
     "clientOfflineSessionMaxLifespan" : "0",
     "oauth2DevicePollingInterval" : "5",
     "clientSessionIdleTimeout" : "0",
+    "actionTokenGeneratedByUserLifespan-execute-actions" : "",
+    "actionTokenGeneratedByUserLifespan-verify-email" : "",
     "clientOfflineSessionIdleTimeout" : "0",
+    "actionTokenGeneratedByUserLifespan-reset-credentials" : "",
     "cibaInterval" : "5",
     "realmReusableOtpCode" : "false",
     "cibaExpiresIn" : "120",
     "oauth2DeviceCodeLifespan" : "600",
+    "actionTokenGeneratedByUserLifespan-idp-verify-account-via-email" : "",
     "parRequestUriLifespan" : "60",
     "clientSessionMaxLifespan" : "0",
-    "frontendUrl": "http://authentication:8080",
+    "frontendUrl" : "http://authentication:8080",
     "acr.loa.map" : "{}",
-    "adminEventsExpiration" : "864000"
+    "adminEventsExpiration" : "864000",
+    "shortVerificationUri" : ""
   },
-  "keycloakVersion" : "22.0.1",
+  "keycloakVersion" : "22.0.0",
   "userManagedAccessAllowed" : false,
   "clientProfiles" : {
     "profiles" : [ ]

--- a/src/main/kotlin/de/cyface/collector/auth/MockedHandlerBuilder.kt
+++ b/src/main/kotlin/de/cyface/collector/auth/MockedHandlerBuilder.kt
@@ -36,10 +36,13 @@ class MockedHandlerBuilder : AuthHandlerBuilder {
     override suspend fun create(apiRouter: Router): AuthenticationHandler {
         val handler = object : AuthenticationHandler {
             override fun handle(event: RoutingContext) {
-                val principal = JsonObject()
-                    .put("username", "test-user")
-                    .put("sub", UUID.randomUUID()) // user id
-                val user = UserImpl(principal, JsonObject())
+                val userId = UUID.randomUUID()
+                val accessToken = JsonObject()
+                    .put("preferred_username", "test-user")
+                    .put("sub", userId.toString())
+                val principal = JsonObject().put("access_token", "mocked-token")
+                val attributes = JsonObject().put("accessToken", accessToken)
+                val user = UserImpl(principal, attributes)
                 event.setUser(user)
 
                 // From AuthenticationHandlerImpl.handle @ `authenticate(ctx, authN -> {..})`

--- a/src/main/kotlin/de/cyface/collector/handler/AuthorizationHandler.kt
+++ b/src/main/kotlin/de/cyface/collector/handler/AuthorizationHandler.kt
@@ -18,44 +18,37 @@
  */
 package de.cyface.collector.handler
 
-import de.cyface.collector.handler.HTTPStatus.ENTITY_UNPARSABLE
 import de.cyface.collector.model.User
 import io.vertx.core.Handler
-import io.vertx.core.http.HttpServerRequest
-import io.vertx.ext.auth.oauth2.Oauth2Credentials
 import io.vertx.ext.web.RoutingContext
 import org.slf4j.LoggerFactory
 import java.util.UUID
 
 /**
- * A `RequestHandler` to ensure correct user authentication.
+ * A handler to ensure correct user authentication.
  * This should be one of the first handlers on each route requiring authorization.
  *
- * @author Klemens Muthmann
- * @author Armin Schnabel
- * @version 2.0.2
+ * Reads user identity from the JWT access token that was already decoded by the auth handler.
+ * Requires the token's `aud` claim to include the backend's configured client ID so that
+ * local JWT validation succeeds.
  */
 class AuthorizationHandler : Handler<RoutingContext> {
     override fun handle(context: RoutingContext) {
         try {
             LOGGER.info("Received new request.")
-            val request: HttpServerRequest = context.request()
-            val headers = request.headers()
-            LOGGER.debug("Request headers: {}", headers)
 
-            // Inform next handler which user is authenticated
-            val contextUser = context.user()
-            val principal = contextUser.principal()
-            val username = Oauth2Credentials(principal).username
-            // The "sub" is the subject claim which represents the unique id of the authenticated user.
-            val uuid = principal.getString("sub")
+            val claims = context.user()?.attributes()?.getJsonObject("accessToken")
+                ?: error("Missing decoded access token (JWT audience validation may have failed)")
+            val username = claims.getString("preferred_username")
+                ?: error("Missing preferred_username in access token")
+            val uuid = claims.getString("sub")
+                ?: error("Missing sub in access token")
             val user = User(UUID.fromString(uuid), username)
             context.put("logged-in-user", user)
 
             context.next()
-        } catch (e: NumberFormatException) {
-            LOGGER.error("Data was not parsable!")
-            context.fail(ENTITY_UNPARSABLE, e)
+        } catch (e: RuntimeException) {
+            context.fail(e)
         }
     }
 

--- a/src/main/kotlin/de/cyface/collector/handler/AuthorizationHandler.kt
+++ b/src/main/kotlin/de/cyface/collector/handler/AuthorizationHandler.kt
@@ -22,7 +22,6 @@ import de.cyface.collector.handler.HTTPStatus.ENTITY_UNPARSABLE
 import de.cyface.collector.model.User
 import io.vertx.core.Handler
 import io.vertx.core.http.HttpServerRequest
-import io.vertx.ext.auth.oauth2.Oauth2Credentials
 import io.vertx.ext.web.RoutingContext
 import org.slf4j.LoggerFactory
 import java.util.UUID
@@ -43,12 +42,13 @@ class AuthorizationHandler : Handler<RoutingContext> {
             val headers = request.headers()
             LOGGER.debug("Request headers: {}", headers)
 
-            // Inform next handler which user is authenticated
-            val contextUser = context.user()
-            val principal = contextUser.principal()
-            val username = Oauth2Credentials(principal).username
-            // The "sub" is the subject claim which represents the unique id of the authenticated user.
-            val uuid = principal.getString("sub")
+            // Read identity from decoded JWT claims (not principal, which only contains the raw token)
+            val claims = context.user()?.attributes()?.getJsonObject("accessToken")
+                ?: error("Missing decoded access token (JWT audience validation may have failed)")
+            val username = claims.getString("preferred_username")
+                ?: error("Missing preferred_username in access token")
+            val uuid = claims.getString("sub")
+                ?: error("Missing sub in access token")
             val user = User(UUID.fromString(uuid), username)
             context.put("logged-in-user", user)
 

--- a/src/main/kotlin/de/cyface/collector/handler/AuthorizationHandler.kt
+++ b/src/main/kotlin/de/cyface/collector/handler/AuthorizationHandler.kt
@@ -22,6 +22,7 @@ import de.cyface.collector.handler.HTTPStatus.ENTITY_UNPARSABLE
 import de.cyface.collector.model.User
 import io.vertx.core.Handler
 import io.vertx.core.http.HttpServerRequest
+import io.vertx.ext.auth.oauth2.Oauth2Credentials
 import io.vertx.ext.web.RoutingContext
 import org.slf4j.LoggerFactory
 import java.util.UUID
@@ -42,13 +43,12 @@ class AuthorizationHandler : Handler<RoutingContext> {
             val headers = request.headers()
             LOGGER.debug("Request headers: {}", headers)
 
-            // Read identity from decoded JWT claims (not principal, which only contains the raw token)
-            val claims = context.user()?.attributes()?.getJsonObject("accessToken")
-                ?: error("Missing decoded access token (JWT audience validation may have failed)")
-            val username = claims.getString("preferred_username")
-                ?: error("Missing preferred_username in access token")
-            val uuid = claims.getString("sub")
-                ?: error("Missing sub in access token")
+            // Inform next handler which user is authenticated
+            val contextUser = context.user()
+            val principal = contextUser.principal()
+            val username = Oauth2Credentials(principal).username
+            // The "sub" is the subject claim which represents the unique id of the authenticated user.
+            val uuid = principal.getString("sub")
             val user = User(UUID.fromString(uuid), username)
             context.put("logged-in-user", user)
 


### PR DESCRIPTION
**This is a change ported from https://github.com/radsim/backend/pull/206 - it does not need to me merged asap.**

## Summary
- Add audience mappers to Keycloak realm config so JWT audience validation succeeds, remove adhocracy-provider, and enable municipality in access tokens
- Update `AuthorizationHandler` to read user identity (`sub`, `preferred_username`) from decoded JWT claims (`attributes().getJsonObject("accessToken")`) instead of `principal()`, which only contains the raw token string after JWT validation succeeds
- Remove unused `Oauth2Credentials` import
-  Replaces the SMTP in the dev keycloak realm JSON to use Mailpit (fake SMTP) which works locally without sending any actual emails but shows the emails at localhost:8025.

## Test plan
- [ ] Deploy with updated realm JSON and verify Keycloak audience mapper is active
- [ ] Confirm authenticated API requests succeed and `AuthorizationHandler` correctly extracts username and UUID from JWT claims
- [ ] Verify error messages surface correctly when JWT validation fails (missing access token, missing claims)