### PR TITLE
Fix file descriptor leak by ending 409 conflict responses

### DIFF
--- a/src/main/kotlin/de/cyface/collector/handler/UploadFailureHandler.kt
+++ b/src/main/kotlin/de/cyface/collector/handler/UploadFailureHandler.kt
@@ -45,7 +45,7 @@ class UploadFailureHandler(private val ctx: RoutingContext) : Handler<Throwable>
 
             is UploadAlreadyExists -> {
                 // Android client interprets this error code as "UPLOAD_SUCCESSFUL" and continues with the next upload.
-                ctx.response().setStatusCode(HTTP_CONFLICT)
+                ctx.response().setStatusCode(HTTP_CONFLICT).end()
             }
 
             else -> {


### PR DESCRIPTION
### Summary:
  - UploadFailureHandler was calling setStatusCode(HTTP_CONFLICT) without .end(), leaving the Vert.x/Netty connection permanently open — one leaked file descriptor per
  duplicate upload attempt.
  - Under high client-side retry volume this caused file descriptor exhaustion.
  - Fix: add .end() to the UploadAlreadyExists branch in UploadFailureHandler.kt.
  
### Test plan
  - Monitor open FDs under repeated duplicate uploads (lsof -p <pid> | wc -l)
  - Confirm Android client still receives 409 and treats it as upload-successful
  - ./gradlew clean test