### PR TITLE
[STAD-916] Map GridFS duplicate-key write error to HTTP 409

### DIFF
--- a/src/main/kotlin/de/cyface/collector/storage/cloud/GoogleCloudStorageService.kt
+++ b/src/main/kotlin/de/cyface/collector/storage/cloud/GoogleCloudStorageService.kt
@@ -167,7 +167,7 @@ class GoogleCloudStorageService(
                     clean(uploadIdentifier)
                         .onSuccess {
                             if (daoFailure is MongoWriteException && daoFailure.code == DUPLICATE_KEY) {
-                                resultPromise.fail(UploadAlreadyExists(daoFailure))
+                                resultPromise.fail(UploadAlreadyExists(e = daoFailure))
                             } else {
                                 resultPromise.fail(daoFailure)
                             }

--- a/src/main/kotlin/de/cyface/collector/storage/exception/UploadAlreadyExists.kt
+++ b/src/main/kotlin/de/cyface/collector/storage/exception/UploadAlreadyExists.kt
@@ -21,8 +21,6 @@ package de.cyface.collector.storage.exception
 /**
  * An `Exception` thrown when a file to upload already exists in the data store.
  *
- * @author Armin Schnabel
- * @version 1.0.0
  * @param e The cause leading to this exception.
  */
-class UploadAlreadyExists(e: Throwable) : Exception(e)
+class UploadAlreadyExists(message: String? = null, e: Throwable? = null) : Exception(message, e)

--- a/src/main/kotlin/de/cyface/collector/storage/gridfs/GridFsStorageService.kt
+++ b/src/main/kotlin/de/cyface/collector/storage/gridfs/GridFsStorageService.kt
@@ -18,6 +18,7 @@
  */
 package de.cyface.collector.storage.gridfs
 
+import com.mongodb.MongoWriteException
 import de.cyface.collector.model.Upload
 import de.cyface.collector.storage.CleanupOperation
 import de.cyface.collector.storage.DataStorageService
@@ -25,6 +26,7 @@ import de.cyface.collector.storage.Status
 import de.cyface.collector.storage.StatusType
 import de.cyface.collector.storage.UploadMetaData
 import de.cyface.collector.storage.exception.ContentRangeNotMatchingFileSize
+import de.cyface.collector.storage.exception.UploadAlreadyExists
 import io.vertx.core.Future
 import io.vertx.core.Promise
 import io.vertx.core.Vertx
@@ -74,7 +76,19 @@ class GridFsStorageService(
                 uploadMetaData
             )
             onTemporaryFileOpenedCall.onSuccess(ret::complete)
-            onTemporaryFileOpenedCall.onFailure(ret::fail)
+            onTemporaryFileOpenedCall.onFailure { cause ->
+                if (cause is MongoWriteException && cause.code == MONGO_DUPLICATE_ENTRY_ERROR_CODE) {
+                    ret.fail(
+                        UploadAlreadyExists(
+                            "Duplicate entry in database for upload ${uploadMetaData.uploadable}!",
+                            cause
+                        )
+                    )
+                } else {
+                    LOGGER.error("Internal Server Error during database access!", cause)
+                    ret.fail(cause)
+                }
+            }
         }
         fsOpenCall.onFailure { cause: Throwable ->
             LOGGER.error("Unable to open temporary file to stream request to!", cause)
@@ -184,15 +198,9 @@ class GridFsStorageService(
                     uploadMetaData
                 )
             }
-            fsPropsCall.onFailure { cause: Throwable ->
-                LOGGER.error("Response: 500, failed to read props from temp file")
-                ret.fail(cause)
-            }
+            fsPropsCall.onFailure(ret::fail)
         }
-        pipeToCall.onFailure { cause: Throwable ->
-            LOGGER.error("Response: 500", cause)
-            ret.fail(cause)
-        }
+        pipeToCall.onFailure(ret::fail)
         return ret.future()
     }
 
@@ -257,5 +265,6 @@ class GridFsStorageService(
          * The logger used by objects of this class. Configure it using `src/main/resources/logback.xml`.
          */
         private val LOGGER = LoggerFactory.getLogger(GridFsStorageService::class.java)
+        private const val MONGO_DUPLICATE_ENTRY_ERROR_CODE = 11000
     }
 }

--- a/src/test/kotlin/de/cyface/collector/storage/gridfs/GridFSStorageIT.kt
+++ b/src/test/kotlin/de/cyface/collector/storage/gridfs/GridFSStorageIT.kt
@@ -31,8 +31,11 @@ import de.cyface.collector.model.metadata.AttachmentMetaData
 import de.cyface.collector.model.metadata.DeviceMetaData
 import de.cyface.collector.model.metadata.GeoLocation
 import de.cyface.collector.model.metadata.MeasurementMetaData
+import de.cyface.collector.storage.Status
 import de.cyface.collector.storage.StatusType
 import de.cyface.collector.storage.UploadMetaData
+import de.cyface.collector.storage.exception.UploadAlreadyExists
+import io.vertx.core.Future
 import io.vertx.core.Vertx
 import io.vertx.core.file.OpenOptions
 import io.vertx.ext.mongo.MongoClient
@@ -121,6 +124,50 @@ class GridFSStorageIT {
                 )
             }
         )
+    }
+
+    @Test
+    fun `storing the same measurement twice fails with UploadAlreadyExists`(vertx: Vertx, context: VertxTestContext) {
+        val config = mongoTest.clientConfiguration()
+            .put("connectTimeoutMS", 3000)
+            .put("socketTimeoutMS", 3000)
+            .put("waitQueueTimeoutMS", 3000)
+            .put("serverSelectionTimeoutMS", 1000)
+        val mongoClient = MongoClient.createShared(vertx, config)
+        val dao = GridFsDao(mongoClient)
+        val oocut = GridFsStorageService(dao, vertx.fileSystem(), uploadFolder)
+        // Reuse the SAME identifier on both stores so the second insert collides on the
+        // unique fs.files index (metadata.deviceId, measurementId, fileType).
+        val duplicate = measurement
+
+        dao.createIndices()
+            .compose { storeOnce(vertx, oocut, duplicate) }
+            .compose { storeOnce(vertx, oocut, duplicate) }
+            .onComplete(
+                context.failing { failure ->
+                    context.verify {
+                        assertThat(failure is UploadAlreadyExists, equalTo(true))
+                    }
+                    context.completeNow()
+                }
+            )
+    }
+
+    /**
+     * Open the test fixture and run a single [GridFsStorageService.store], using the provided [measurement] metadata
+     * and a fresh upload identifier.
+     */
+    private fun storeOnce(vertx: Vertx, oocut: GridFsStorageService, measurement: Measurement): Future<Status> {
+        val fileSystem = vertx.fileSystem()
+        val testFileURI = GridFSStorageIT::class.java.getResource("/test.bin")?.toURI()?.let { Paths.get(it) }
+        assertNotNull(testFileURI)
+        return fileSystem.open(testFileURI.absolutePathString(), OpenOptions()).compose { asyncFile ->
+            val user = User(UUID.randomUUID(), "test-user")
+            val uploadIdentifier = UUID.randomUUID()
+            val contentRange = ContentRange(0L, 3L, 4L)
+            val uploadMetaData = UploadMetaData(user, contentRange, uploadIdentifier, measurement)
+            oocut.store(asyncFile, uploadMetaData)
+        }
     }
 
     private val measurement: Measurement


### PR DESCRIPTION
When two uploads of the same (deviceId, measurementId, fileType) race past the isStored pre-check, both reach the store path and the unique fs.files index rejects the second insert. The GridFS store path did not handle the duplicate-key error (code 11000), so the raw MongoWriteException propagated through UploadFailureHandler as a 500. Clients treat a 500 as a retry rather than as "already stored".

Mirror the cloud storage path: catch MongoWriteException 11000 in the GridFS store path and fail with UploadAlreadyExists, so the racing client receives a
409. Add a GridFS integration test covering a duplicate store.